### PR TITLE
Add MCP endpoint for read-only reservations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ This is a **FastAPI** application that exposes a simplified REST API on top of a
 - **Structured logging**: all logging goes through `structlog` with a shared pipeline that also captures uvicorn's stdlib logs. `/health` endpoint access logs are suppressed. Configured in `logging_config.py`.
 - **Settings**: all configuration is via environment variables with the `AGGREGATOR_PROXY_` prefix, managed by `pydantic-settings` (`settings.py`). The required variables are `AGGREGATOR_PROXY_PROVIDER_URL`, `AGGREGATOR_PROXY_REQUESTER_NSA`, `AGGREGATOR_PROXY_PROVIDER_NSA`, and `AGGREGATOR_PROXY_BASE_URL`.
 - **Dual-ingress authentication**: when `AUTH_ENABLED=true`, every request to `/reservations` must be authenticated via OIDC (JWT) or mTLS (header from nsi-auth). OIDC is active when `OIDC_ISSUER` is set; mTLS is active when `MTLS_HEADER` is set. The `/health` endpoint is always unauthenticated. The `/nsi/v2/callback` endpoint requires mTLS (not OIDC) when auth is enabled and `MTLS_HEADER` is set — the aggregator is a machine client, not a browser user. OIDC discovery validates that both `jwks_uri` and `userinfo_endpoint` are available, failing fast at startup if not. Group-based authorization via userinfo endpoint. Separate vanilla httpx client for OIDC calls (not the mTLS NSI client). `OIDC_REQUIRED_GROUPS` must be `[]` (not empty string) when no groups are required.
+- **Optional MCP sub-app**: when `MCP_ENABLED=true`, an `aggregator_proxy/mcp_server.py` factory builds a `FastMCP.from_fastapi()` sub-app mounted at `/mcp`. Route maps expose only `GET /reservations` (Resource) and `GET /reservations/{connectionId}` (ResourceTemplate); everything else is `MCPType.EXCLUDE`. The MCP-internal call to `/reservations` runs through the existing FastAPI handlers and dependencies, so no business logic is duplicated. When `auth_enabled=true`, an httpx event hook forwards the MCP client's `Authorization` header to the internal call so the existing `get_authenticated_user` dependency re-validates.
 
 ### Module layout
 
@@ -137,6 +138,9 @@ The state mapping module (`aggregator_proxy/state_mapping.py`) maps NSI sub-stat
 | `AGGREGATOR_PROXY_OIDC_REQUIRED_GROUPS` | No | `[]` | Groups required for access (JSON array or comma-separated) |
 | `AGGREGATOR_PROXY_OIDC_JWKS_CACHE_LIFESPAN` | No | `300` | JWKS key cache TTL in seconds |
 | `AGGREGATOR_PROXY_OIDC_USERINFO_CACHE_TTL` | No | `60` | Userinfo response cache TTL in seconds |
+| `AGGREGATOR_PROXY_MCP_ENABLED` | No | `false` | Mount the MCP sub-app at `MCP_PATH`. Off by default; opt-in. |
+| `AGGREGATOR_PROXY_MCP_PATH` | No | `/mcp` | Mount path for the MCP sub-app. |
+| `AGGREGATOR_PROXY_MCP_AUTH_ENABLED` | No | `false` | Require an OIDC JWT on the MCP endpoint. Validated by FastMCP's `JWTVerifier` using the same `OIDC_*` settings. Must be `true` whenever `AUTH_ENABLED=true`. |
 
 ### Non-obvious invariants
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,8 +139,8 @@ The state mapping module (`aggregator_proxy/state_mapping.py`) maps NSI sub-stat
 | `AGGREGATOR_PROXY_OIDC_JWKS_CACHE_LIFESPAN` | No | `300` | JWKS key cache TTL in seconds |
 | `AGGREGATOR_PROXY_OIDC_USERINFO_CACHE_TTL` | No | `60` | Userinfo response cache TTL in seconds |
 | `AGGREGATOR_PROXY_MCP_ENABLED` | No | `false` | Mount the MCP sub-app at `MCP_PATH`. Off by default; opt-in. |
-| `AGGREGATOR_PROXY_MCP_PATH` | No | `/mcp` | Mount path for the MCP sub-app. |
-| `AGGREGATOR_PROXY_MCP_AUTH_ENABLED` | No | `false` | Require an OIDC JWT on the MCP endpoint. Validated by FastMCP's `JWTVerifier` using the issuer/audience/JWKS URI from the existing `OIDC_*` settings. Group-based authorization is not enforced on MCP. Must be `true` whenever `AUTH_ENABLED=true`. |
+| `AGGREGATOR_PROXY_MCP_PATH` | No | `/mcp` | Mount path for the MCP sub-app. Must start with `/` and not end with `/`; validated at startup. |
+| `AGGREGATOR_PROXY_MCP_AUTH_ENABLED` | No | `false` | Require an OIDC JWT on the MCP endpoint. Validated by FastMCP's `JWTVerifier` using the issuer/audience/JWKS URI from the existing `OIDC_*` settings. Must be `true` whenever `AUTH_ENABLED=true`, and `OIDC_REQUIRED_GROUPS` must be empty when this is `true` (group authorization is not supported on MCP — see startup validation in `_validate_mcp_settings`). |
 
 ### Non-obvious invariants
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ The state mapping module (`aggregator_proxy/state_mapping.py`) maps NSI sub-stat
 | `AGGREGATOR_PROXY_OIDC_USERINFO_CACHE_TTL` | No | `60` | Userinfo response cache TTL in seconds |
 | `AGGREGATOR_PROXY_MCP_ENABLED` | No | `false` | Mount the MCP sub-app at `MCP_PATH`. Off by default; opt-in. |
 | `AGGREGATOR_PROXY_MCP_PATH` | No | `/mcp` | Mount path for the MCP sub-app. |
-| `AGGREGATOR_PROXY_MCP_AUTH_ENABLED` | No | `false` | Require an OIDC JWT on the MCP endpoint. Validated by FastMCP's `JWTVerifier` using the same `OIDC_*` settings. Must be `true` whenever `AUTH_ENABLED=true`. |
+| `AGGREGATOR_PROXY_MCP_AUTH_ENABLED` | No | `false` | Require an OIDC JWT on the MCP endpoint. Validated by FastMCP's `JWTVerifier` using the issuer/audience/JWKS URI from the existing `OIDC_*` settings. Group-based authorization is not enforced on MCP. Must be `true` whenever `AUTH_ENABLED=true`. |
 
 ### Non-obvious invariants
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,31 @@ The state mapping module (`aggregator_proxy/state_mapping.py`) maps NSI sub-stat
 | `AGGREGATOR_PROXY_OIDC_JWKS_CACHE_LIFESPAN` | No | `300` | JWKS key cache TTL in seconds |
 | `AGGREGATOR_PROXY_OIDC_USERINFO_CACHE_TTL` | No | `60` | Userinfo response cache TTL in seconds |
 
+### Non-obvious invariants
+
+- **Register pending future before sending SOAP**: in every operation that awaits an async callback (reserve, commit, provision, release, terminate, queryRecursive), `store.register_pending(correlation_id)` is called *before* the outbound SOAP POST. If the future were registered after, the callback could arrive and be dropped before the future exists.
+- **`DataPlaneStateChange` dual resolution**: the callback router resolves this message via *both* `resolve_pending(correlation_id, ...)` and `resolve_pending_by_connection(connection_id, ...)`. The aggregator sends data-plane notifications with its own self-generated correlationId (not the correlationId used in the provision/release request), so the operation background tasks register a connection-keyed future (`register_pending_by_connection`) that `_await_dataplane_change` loops on.
+- **Reservation store is in-memory only**: there is no database. On restart the store is repopulated from `querySummarySync` at startup, but in-flight `asyncio.Future` objects and pending correlation tracking are lost. Any operation that was waiting for a callback when the process restarted will never complete.
+
+### Testing
+
+Tests use `pytest-asyncio` in `auto` mode (all async test functions run automatically). Outbound HTTP calls are mocked with `pytest-httpx` (`respx`-style). The `tests/conftest.py` provides shared helpers:
+
+- `build_query_summary_sync_response(connection_id, correlation_id, ...)` — SOAP `querySummarySyncConfirmed` response
+- `build_query_notification_sync_response(correlation_id, *error_events)` — SOAP `queryNotificationSyncConfirmed` response
+- `build_error_event_xml(...)` — `<errorEvent>` XML fragment
+- `build_child_xml(...)` / `build_connection_states_xml(...)` — child segment XML fragments
+- `build_query_summary_sync_response_with_children(...)` / `build_query_recursive_confirmed_response(...)` — responses with path children
+- `build_soap_envelope(body_xml, correlation_id)` — wraps any body XML in a full SOAP envelope
+- `build_acknowledgment_xml(correlation_id)` — NSI acknowledgment response
+- `get_pending_correlation_id(store)` — extract the single pending correlationId from a store (asserts exactly one)
+- `make_reservation(...)` — build a `Reservation` with sensible defaults
+- `store` fixture — fresh `ReservationStore` per test
+
+### Local env file
+
+`aggregator_proxy.env` in the repo root can hold `AGGREGATOR_PROXY_*` values as `KEY=VALUE` lines. Environment variables take precedence. The file is read automatically on startup if present in the working directory.
+
 ### Code style
 
 - Line length: 120 characters

--- a/README.md
+++ b/README.md
@@ -340,10 +340,14 @@ All state-changing operations (POST, DELETE) and the NSI callback endpoint are e
 | Variable | Default | Description |
 |---|---|---|
 | `AGGREGATOR_PROXY_MCP_ENABLED` | `false` | Mount the MCP sub-app. Opt-in; the feature is disabled by default. |
-| `AGGREGATOR_PROXY_MCP_PATH` | `/mcp` | Mount path for the MCP sub-app. |
-| `AGGREGATOR_PROXY_MCP_AUTH_ENABLED` | `false` | Require an OIDC JWT on the MCP endpoint. Validated by FastMCP's `JWTVerifier` using the configured OIDC issuer, audience, and JWKS URI. Group-based authorization (`OIDC_REQUIRED_GROUPS`) is not enforced on the MCP endpoint. |
+| `AGGREGATOR_PROXY_MCP_PATH` | `/mcp` | Mount path for the MCP sub-app. Must start with `/` and must not end with `/`. |
+| `AGGREGATOR_PROXY_MCP_AUTH_ENABLED` | `false` | Require an OIDC JWT on the MCP endpoint. Validated by FastMCP's `JWTVerifier` using the configured OIDC issuer, audience, and JWKS URI. Group-based authorization (`OIDC_REQUIRED_GROUPS`) is not supported on the MCP endpoint; see startup validation below. |
 
-**Startup validation:** when `AUTH_ENABLED=true`, `MCP_AUTH_ENABLED` must also be `true` — otherwise the proxy would expose authenticated data via an unauthenticated MCP endpoint. The proxy refuses to start in that configuration. Additionally, when `MCP_AUTH_ENABLED=true`, `OIDC_JWKS_URI` must be set explicitly (auto-discovery is not available at module load time).
+**Startup validation:** the proxy refuses to start when any of these hold:
+
+- `AUTH_ENABLED=true` and `MCP_AUTH_ENABLED=false` — would expose authenticated data via an unauthenticated MCP endpoint.
+- `MCP_AUTH_ENABLED=true` and `OIDC_JWKS_URI` empty — OIDC discovery only runs in the async lifespan, but `JWTVerifier` needs the JWKS URI at module load time.
+- `MCP_AUTH_ENABLED=true` and `OIDC_REQUIRED_GROUPS` non-empty — `JWTVerifier` validates the JWT but does not call the userinfo endpoint, and only the `Authorization` header is forwarded to the internal `/reservations` call. The userinfo group lookup in `get_authenticated_user` would therefore never succeed, so the combination is rejected explicitly rather than producing opaque 401s at request time.
 
 ### Minimal client example
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ All state-changing operations (POST, DELETE) and the NSI callback endpoint are e
 |---|---|---|
 | `AGGREGATOR_PROXY_MCP_ENABLED` | `false` | Mount the MCP sub-app. Opt-in; the feature is disabled by default. |
 | `AGGREGATOR_PROXY_MCP_PATH` | `/mcp` | Mount path for the MCP sub-app. |
-| `AGGREGATOR_PROXY_MCP_AUTH_ENABLED` | `false` | Require an OIDC JWT on the MCP endpoint. Validated by FastMCP's `JWTVerifier` using the same `OIDC_*` settings as the REST endpoints. |
+| `AGGREGATOR_PROXY_MCP_AUTH_ENABLED` | `false` | Require an OIDC JWT on the MCP endpoint. Validated by FastMCP's `JWTVerifier` using the configured OIDC issuer, audience, and JWKS URI. Group-based authorization (`OIDC_REQUIRED_GROUPS`) is not enforced on the MCP endpoint. |
 
 **Startup validation:** when `AUTH_ENABLED=true`, `MCP_AUTH_ENABLED` must also be `true` — otherwise the proxy would expose authenticated data via an unauthenticated MCP endpoint. The proxy refuses to start in that configuration. Additionally, when `MCP_AUTH_ENABLED=true`, `OIDC_JWKS_URI` must be set explicitly (auto-discovery is not available at module load time).
 
@@ -357,7 +357,17 @@ transport = StreamableHttpTransport(
 )
 
 async with Client(transport) as client:
-    contents = await client.read_resource("list_reservations")
+    # Discover the list resource and read it
+    resources = await client.list_resources()
+    list_resource = next(r for r in resources if r.name == "list_reservations")
+    contents = await client.read_resource(list_resource.uri)
+    print(contents[0].text)
+
+    # Or read a single reservation by filling in the URI template
+    templates = await client.list_resource_templates()
+    get_template = next(t for t in templates if t.name == "get_reservation")
+    uri = get_template.uriTemplate.replace("{connectionId}", "<your-connection-id>")
+    contents = await client.read_resource(uri)
     print(contents[0].text)
 ```
 

--- a/README.md
+++ b/README.md
@@ -324,6 +324,43 @@ When authentication is enabled, endpoints may return these error responses:
 
 **Defense-in-depth:** The OIDC ingress should strip the `X-Auth-Method` header to prevent clients from spoofing mTLS authentication. With nginx, use `configuration-snippet: proxy_set_header X-Auth-Method "";`. With Traefik, use a Headers middleware with `customRequestHeaders: { X-Auth-Method: "" }`.
 
+## MCP Endpoint (optional)
+
+The Aggregator Proxy can expose its read-only reservation endpoints as a [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server, mounted at `/mcp`. This lets AI agents (Claude Desktop, custom agents using `fastmcp.Client`, etc.) list and inspect reservations as MCP **Resources**.
+
+Only the two GET operations are exposed:
+
+- `GET /reservations` → MCP Resource `list_reservations`
+- `GET /reservations/{connectionId}` → MCP ResourceTemplate `get_reservation`
+
+All state-changing operations (POST, DELETE) and the NSI callback endpoint are explicitly excluded from MCP.
+
+### Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `AGGREGATOR_PROXY_MCP_ENABLED` | `false` | Mount the MCP sub-app. Opt-in; the feature is disabled by default. |
+| `AGGREGATOR_PROXY_MCP_PATH` | `/mcp` | Mount path for the MCP sub-app. |
+| `AGGREGATOR_PROXY_MCP_AUTH_ENABLED` | `false` | Require an OIDC JWT on the MCP endpoint. Validated by FastMCP's `JWTVerifier` using the same `OIDC_*` settings as the REST endpoints. |
+
+**Startup validation:** when `AUTH_ENABLED=true`, `MCP_AUTH_ENABLED` must also be `true` — otherwise the proxy would expose authenticated data via an unauthenticated MCP endpoint. The proxy refuses to start in that configuration. Additionally, when `MCP_AUTH_ENABLED=true`, `OIDC_JWKS_URI` must be set explicitly (auto-discovery is not available at module load time).
+
+### Minimal client example
+
+```python
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+transport = StreamableHttpTransport(
+    url="https://proxy.example.com/mcp/",
+    headers={"Authorization": "Bearer <your-token>"},
+)
+
+async with Client(transport) as client:
+    contents = await client.read_resource("list_reservations")
+    print(contents[0].text)
+```
+
 ## API Endpoints
 
 ### POST /reservations

--- a/aggregator_proxy/main.py
+++ b/aggregator_proxy/main.py
@@ -151,16 +151,26 @@ def _validate_mcp_settings() -> None:
     """Refuse to start when MCP/REST auth flags are inconsistent.
 
     Raises:
-        SystemExit: If REST auth is enabled but MCP auth is not, or if MCP auth
-            is enabled without an explicit OIDC JWKS URI. Auto-discovery is not
-            available at module load time, so the JWKS URI must be set explicitly
-            when MCP auth is enabled.
+        SystemExit: If REST auth is enabled but MCP auth is not, if MCP auth
+            is enabled without an explicit OIDC JWKS URI, or if MCP auth is
+            enabled while OIDC group authorization is required. FastMCP's
+            ``JWTVerifier`` validates the token but does not call the userinfo
+            endpoint, and the token-forwarding event hook only forwards the
+            ``Authorization`` header — not the ``X-Auth-Request-Access-Token``
+            header that ``get_authenticated_user`` requires for the userinfo
+            group lookup. The internal call would therefore always 401, so we
+            fail fast instead.
     """
     if settings.auth_enabled and not settings.mcp_auth_enabled:
         raise SystemExit("AGGREGATOR_PROXY_MCP_AUTH_ENABLED must be true when AGGREGATOR_PROXY_AUTH_ENABLED is true")
     if settings.mcp_auth_enabled and not settings.oidc_jwks_uri:
         raise SystemExit(
             "AGGREGATOR_PROXY_OIDC_JWKS_URI must be set explicitly when AGGREGATOR_PROXY_MCP_AUTH_ENABLED is true"
+        )
+    if settings.mcp_auth_enabled and settings.oidc_required_groups:
+        raise SystemExit(
+            "AGGREGATOR_PROXY_OIDC_REQUIRED_GROUPS must be empty when AGGREGATOR_PROXY_MCP_AUTH_ENABLED is true; "
+            "group-based authorization is not enforced on the MCP endpoint"
         )
 
 

--- a/aggregator_proxy/main.py
+++ b/aggregator_proxy/main.py
@@ -25,9 +25,11 @@ import structlog
 import uvicorn
 from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse, Response
+from fastmcp.utilities.lifespan import combine_lifespans
 
 from aggregator_proxy.auth import OIDCProvider, get_authenticated_user, get_mtls_authenticated_callback
 from aggregator_proxy.logging_config import configure_logging
+from aggregator_proxy.mcp_server import build_mcp
 from aggregator_proxy.nsi_client import create_nsi_client
 from aggregator_proxy.reservation_store import ReservationStore
 from aggregator_proxy.routers import reservations
@@ -145,11 +147,6 @@ async def health() -> Response:
     return Response(status_code=200)
 
 
-from fastmcp.utilities.lifespan import combine_lifespans  # noqa: E402
-
-from aggregator_proxy.mcp_server import build_mcp  # noqa: E402
-
-
 def _validate_mcp_settings() -> None:
     """Refuse to start when MCP/REST auth flags are inconsistent.
 
@@ -162,16 +159,22 @@ def _validate_mcp_settings() -> None:
     if settings.auth_enabled and not settings.mcp_auth_enabled:
         raise SystemExit("AGGREGATOR_PROXY_MCP_AUTH_ENABLED must be true when AGGREGATOR_PROXY_AUTH_ENABLED is true")
     if settings.mcp_auth_enabled and not settings.oidc_jwks_uri:
-        raise SystemExit("AGGREGATOR_PROXY_OIDC_JWKS_URI must be set explicitly when MCP_AUTH_ENABLED is true")
+        raise SystemExit(
+            "AGGREGATOR_PROXY_OIDC_JWKS_URI must be set explicitly when AGGREGATOR_PROXY_MCP_AUTH_ENABLED is true"
+        )
 
 
-if settings.mcp_enabled:
+def _setup_mcp(app: FastAPI) -> None:
+    """Validate MCP settings, build the MCP sub-app, and mount it on `app`."""
     _validate_mcp_settings()
-
     mcp_app = build_mcp(app).http_app(path="/")
     original_lifespan = app.router.lifespan_context
     app.router.lifespan_context = combine_lifespans(original_lifespan, mcp_app.lifespan)
     app.mount(settings.mcp_path, mcp_app)
+
+
+if settings.mcp_enabled:
+    _setup_mcp(app)
 
 
 def run() -> None:

--- a/aggregator_proxy/main.py
+++ b/aggregator_proxy/main.py
@@ -145,6 +145,35 @@ async def health() -> Response:
     return Response(status_code=200)
 
 
+from fastmcp.utilities.lifespan import combine_lifespans  # noqa: E402
+
+from aggregator_proxy.mcp_server import build_mcp  # noqa: E402
+
+
+def _validate_mcp_settings() -> None:
+    """Refuse to start when MCP/REST auth flags are inconsistent.
+
+    Raises:
+        SystemExit: If REST auth is enabled but MCP auth is not, or if MCP auth
+            is enabled without an explicit OIDC JWKS URI. Auto-discovery is not
+            available at module load time, so the JWKS URI must be set explicitly
+            when MCP auth is enabled.
+    """
+    if settings.auth_enabled and not settings.mcp_auth_enabled:
+        raise SystemExit("AGGREGATOR_PROXY_MCP_AUTH_ENABLED must be true when AGGREGATOR_PROXY_AUTH_ENABLED is true")
+    if settings.mcp_auth_enabled and not settings.oidc_jwks_uri:
+        raise SystemExit("AGGREGATOR_PROXY_OIDC_JWKS_URI must be set explicitly when MCP_AUTH_ENABLED is true")
+
+
+if settings.mcp_enabled:
+    _validate_mcp_settings()
+
+    mcp_app = build_mcp(app).http_app(path="/")
+    original_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = combine_lifespans(original_lifespan, mcp_app.lifespan)
+    app.mount(settings.mcp_path, mcp_app)
+
+
 def run() -> None:
     """Entry point invoked by the ``aggregator-proxy`` CLI command."""
     uvicorn.run(

--- a/aggregator_proxy/mcp_server.py
+++ b/aggregator_proxy/mcp_server.py
@@ -22,6 +22,8 @@ from typing import Any
 import httpx
 from fastapi import FastAPI
 from fastmcp import FastMCP
+from fastmcp.server.auth import AuthProvider
+from fastmcp.server.auth.providers.jwt import JWTVerifier
 from fastmcp.server.context import request_ctx
 from fastmcp.server.providers.openapi import MCPType, RouteMap
 
@@ -44,6 +46,22 @@ async def _forward_user_token(request: httpx.Request) -> None:
         request.headers["Authorization"] = token
 
 
+def _build_auth() -> AuthProvider | None:
+    """Build an MCP-level OIDC auth provider, or None if MCP auth is disabled.
+
+    Returns a ``JWTVerifier`` that validates incoming MCP request tokens against the
+    configured OIDC issuer/audience using the JWKS endpoint. ``JWTVerifier`` is itself
+    an ``AuthProvider``, so it can be passed directly to ``FastMCP`` as ``auth``.
+    """
+    if not settings.mcp_auth_enabled:
+        return None
+    return JWTVerifier(
+        jwks_uri=settings.oidc_jwks_uri,
+        issuer=settings.oidc_issuer,
+        audience=settings.oidc_audience,
+    )
+
+
 def build_mcp(api: FastAPI) -> FastMCP:
     """Build a FastMCP server from the given FastAPI app, exposing only GET /reservations."""
     httpx_kwargs: dict[str, Any] = {}
@@ -53,6 +71,7 @@ def build_mcp(api: FastAPI) -> FastMCP:
     return FastMCP.from_fastapi(
         app=api,
         name="NSI Aggregator Proxy",
+        auth=_build_auth(),
         route_maps=[
             RouteMap(methods=["GET"], pattern=_DETAIL_PATTERN, mcp_type=MCPType.RESOURCE_TEMPLATE),
             RouteMap(methods=["GET"], pattern=_LIST_PATTERN, mcp_type=MCPType.RESOURCE),

--- a/aggregator_proxy/mcp_server.py
+++ b/aggregator_proxy/mcp_server.py
@@ -17,16 +17,39 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+import httpx
 from fastapi import FastAPI
 from fastmcp import FastMCP
+from fastmcp.server.context import request_ctx
 from fastmcp.server.providers.openapi import MCPType, RouteMap
+
+from aggregator_proxy.settings import settings
 
 _DETAIL_PATTERN = r"^/reservations/\{[^}]+\}$"
 _LIST_PATTERN = r"^/reservations$"
 
 
+async def _forward_user_token(request: httpx.Request) -> None:
+    """Copy the MCP client's Authorization header onto the internal /reservations call."""
+    ctx = request_ctx.get(None)
+    if ctx is None:
+        return
+    incoming = getattr(ctx, "request", None)
+    if incoming is None:
+        return
+    token = incoming.headers.get("authorization")
+    if token:
+        request.headers["Authorization"] = token
+
+
 def build_mcp(api: FastAPI) -> FastMCP:
     """Build a FastMCP server from the given FastAPI app, exposing only GET /reservations."""
+    httpx_kwargs: dict[str, Any] = {}
+    if settings.auth_enabled:
+        httpx_kwargs["event_hooks"] = {"request": [_forward_user_token]}
+
     return FastMCP.from_fastapi(
         app=api,
         name="NSI Aggregator Proxy",
@@ -35,4 +58,5 @@ def build_mcp(api: FastAPI) -> FastMCP:
             RouteMap(methods=["GET"], pattern=_LIST_PATTERN, mcp_type=MCPType.RESOURCE),
             RouteMap(mcp_type=MCPType.EXCLUDE),
         ],
+        httpx_client_kwargs=httpx_kwargs,
     )

--- a/aggregator_proxy/mcp_server.py
+++ b/aggregator_proxy/mcp_server.py
@@ -1,0 +1,38 @@
+# Copyright 2026 SURF
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""FastMCP sub-app builder exposing GET /reservations as MCP Resources."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastmcp import FastMCP
+from fastmcp.server.providers.openapi import MCPType, RouteMap
+
+_DETAIL_PATTERN = r"^/reservations/\{[^}]+\}$"
+_LIST_PATTERN = r"^/reservations$"
+
+
+def build_mcp(api: FastAPI) -> FastMCP:
+    """Build a FastMCP server from the given FastAPI app, exposing only GET /reservations."""
+    return FastMCP.from_fastapi(
+        app=api,
+        name="NSI Aggregator Proxy",
+        route_maps=[
+            RouteMap(methods=["GET"], pattern=_DETAIL_PATTERN, mcp_type=MCPType.RESOURCE_TEMPLATE),
+            RouteMap(methods=["GET"], pattern=_LIST_PATTERN, mcp_type=MCPType.RESOURCE),
+            RouteMap(mcp_type=MCPType.EXCLUDE),
+        ],
+    )

--- a/aggregator_proxy/routers/reservations.py
+++ b/aggregator_proxy/routers/reservations.py
@@ -1074,6 +1074,7 @@ def _build_reservation_detail(
     "/{connectionId}",
     response_model=ReservationDetail,
     summary="Get reservation details",
+    operation_id="get_reservation",
 )
 async def get_reservation(
     connectionId: str,
@@ -1101,6 +1102,7 @@ async def get_reservation(
     "",
     response_model=ReservationsListResponse,
     summary="List all reservations",
+    operation_id="list_reservations",
 )
 async def list_reservations(
     nsi_client: NsiClient,

--- a/aggregator_proxy/settings.py
+++ b/aggregator_proxy/settings.py
@@ -81,6 +81,10 @@ class Settings(BaseSettings):
     oidc_jwks_cache_lifespan: int = 300
     oidc_userinfo_cache_ttl: int = 60
 
+    mcp_enabled: bool = False
+    mcp_path: str = "/mcp"
+    mcp_auth_enabled: bool = False
+
     @field_validator("oidc_required_groups", mode="before")
     @classmethod
     def parse_comma_separated_groups(cls, v: object) -> object:

--- a/aggregator_proxy/settings.py
+++ b/aggregator_proxy/settings.py
@@ -100,5 +100,15 @@ class Settings(BaseSettings):
                 raise ValueError(f"Invalid JSON in OIDC_REQUIRED_GROUPS: {e}") from e
         return [g.strip() for g in v.split(",") if g.strip()]
 
+    @field_validator("mcp_path")
+    @classmethod
+    def validate_mcp_path(cls, v: str) -> str:
+        """Require a leading slash and reject trailing slash so app.mount behaves predictably."""
+        if not v.startswith("/"):
+            raise ValueError("AGGREGATOR_PROXY_MCP_PATH must start with '/'")
+        if len(v) > 1 and v.endswith("/"):
+            raise ValueError("AGGREGATOR_PROXY_MCP_PATH must not end with '/'")
+        return v
+
 
 settings = Settings()  # type: ignore[call-arg]

--- a/docs/superpowers/plans/2026-05-20-mcp-reservations-endpoint.md
+++ b/docs/superpowers/plans/2026-05-20-mcp-reservations-endpoint.md
@@ -1,0 +1,981 @@
+# MCP Reservations Endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose `GET /reservations` and `GET /reservations/{connectionId}` as MCP Resources via a `FastMCP.from_fastapi()` sub-app mounted at `/mcp`, while leaving all other routes hidden from MCP clients.
+
+**Architecture:** A new `aggregator_proxy/mcp_server.py` builds a `FastMCP` instance from the existing FastAPI app, using route maps to keep only the two GET reservation paths (everything else is `MCPType.EXCLUDE`). When `mcp_auth_enabled=true`, a `JWTVerifier`/`OAuthProvider` validates the MCP client's OIDC token, and an httpx event hook forwards that token to the internal `/reservations` call so the existing `get_authenticated_user` dependency re-validates. Lifespans are combined so FastMCP's session-store starts/stops cleanly.
+
+**Tech Stack:** Python 3.13, FastAPI, FastMCP 3.x, uv, pytest (`pytest-asyncio` in auto mode), `pytest-httpx`, structlog, pydantic-settings.
+
+**Spec:** `docs/superpowers/specs/2026-05-20-mcp-reservations-endpoint-design.md`
+
+---
+
+## Task 1: Add fastmcp dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Add fastmcp to `[project]` dependencies**
+
+Edit `pyproject.toml`, inserting one line in the `dependencies` list (keep the existing pinned-style format):
+
+```toml
+dependencies = [
+    "fastapi[standard]==0.136.1",
+    "fastmcp==3.2.4",
+    "httpx==0.28.1",
+    "lxml==6.1.0",
+    "pydantic-settings==2.14.1",
+    "PyJWT[crypto]==2.12.1",
+    "structlog==25.5.0",
+    "uvicorn[standard]==0.46.0",
+]
+```
+
+(If a newer 3.x is available at implementation time, pick the latest stable 3.x release.)
+
+- [ ] **Step 2: Sync and confirm import**
+
+Run: `uv sync && uv run python -c "from fastmcp import FastMCP; from fastmcp.server.providers.openapi import RouteMap, MCPType; from fastmcp.utilities.lifespan import combine_lifespans; print('ok')"`
+
+Expected: `ok` printed, no `ImportError`. If any import fails, the chosen FastMCP version may have moved symbols — check the FastMCP changelog and adjust import paths in later tasks accordingly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "Add fastmcp dependency for MCP endpoint support"
+```
+
+---
+
+## Task 2: Add MCP settings
+
+**Files:**
+- Modify: `aggregator_proxy/settings.py`
+- Test: `tests/test_settings.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_settings.py` (or create the file if it doesn't already have a similar pattern — verify first by reading the existing file):
+
+```python
+def test_mcp_settings_defaults() -> None:
+    from aggregator_proxy.settings import Settings
+
+    s = Settings()
+    assert s.mcp_enabled is False
+    assert s.mcp_path == "/mcp"
+    assert s.mcp_auth_enabled is False
+
+
+def test_mcp_settings_from_env(monkeypatch) -> None:
+    from aggregator_proxy.settings import Settings
+
+    monkeypatch.setenv("AGGREGATOR_PROXY_MCP_ENABLED", "true")
+    monkeypatch.setenv("AGGREGATOR_PROXY_MCP_PATH", "/custom-mcp")
+    monkeypatch.setenv("AGGREGATOR_PROXY_MCP_AUTH_ENABLED", "true")
+
+    s = Settings()
+    assert s.mcp_enabled is True
+    assert s.mcp_path == "/custom-mcp"
+    assert s.mcp_auth_enabled is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_settings.py::test_mcp_settings_defaults tests/test_settings.py::test_mcp_settings_from_env -v`
+
+Expected: FAIL with `AttributeError: ... has no attribute 'mcp_enabled'`.
+
+- [ ] **Step 3: Add settings fields**
+
+In `aggregator_proxy/settings.py`, add these three fields to the `Settings` class (place them next to the other optional settings; follow the existing style — type annotations, defaults, no docstring needed):
+
+```python
+mcp_enabled: bool = False
+mcp_path: str = "/mcp"
+mcp_auth_enabled: bool = False
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_settings.py -v`
+
+Expected: all settings tests PASS (both the new ones and any existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aggregator_proxy/settings.py tests/test_settings.py
+git commit -m "Add MCP_ENABLED, MCP_PATH, MCP_AUTH_ENABLED settings"
+```
+
+---
+
+## Task 3: Add operation_id to reservation GET routes
+
+**Files:**
+- Modify: `aggregator_proxy/routers/reservations.py` (the two `@router.get` decorators on `get_reservation` and `list_reservations`)
+- Test: `tests/test_get_reservations.py` (add one assertion at the end)
+
+The `operation_id` becomes the MCP resource/template name. Without an explicit value, FastAPI auto-generates `get_reservation_reservations__connectionId__get`, which is ugly.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_get_reservations.py`:
+
+```python
+def test_reservation_get_routes_have_explicit_operation_ids() -> None:
+    """Operation IDs are used as MCP component names and must be stable, clean strings."""
+    schema = app.openapi()
+    list_op = schema["paths"]["/reservations"]["get"]["operationId"]
+    detail_op = schema["paths"]["/reservations/{connectionId}"]["get"]["operationId"]
+    assert list_op == "list_reservations"
+    assert detail_op == "get_reservation"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_get_reservations.py::test_reservation_get_routes_have_explicit_operation_ids -v`
+
+Expected: FAIL — assertion on the auto-generated operation ID like `list_reservations_reservations_get`.
+
+- [ ] **Step 3: Add operation_id to both GET decorators**
+
+In `aggregator_proxy/routers/reservations.py`, find the two GET routes and add `operation_id`:
+
+```python
+@router.get(
+    "/{connectionId}",
+    response_model=ReservationDetail,
+    summary="Get reservation details",
+    operation_id="get_reservation",
+)
+async def get_reservation(...):
+    ...
+
+
+@router.get(
+    "",
+    response_model=ReservationsListResponse,
+    summary="List all reservations",
+    operation_id="list_reservations",
+)
+async def list_reservations(...):
+    ...
+```
+
+Leave the function bodies completely unchanged.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_get_reservations.py -v`
+
+Expected: all PASS (including the new assertion and all existing get-reservation tests, since handler logic is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aggregator_proxy/routers/reservations.py tests/test_get_reservations.py
+git commit -m "Set explicit operation_id on GET /reservations routes"
+```
+
+---
+
+## Task 4: Create `build_mcp` factory with route maps
+
+**Files:**
+- Create: `aggregator_proxy/mcp_server.py`
+- Test: `tests/test_mcp_routes.py`
+
+This task gets the route filtering right with **no auth wiring yet** (auth is layered in Tasks 5 and 6). It establishes the file and proves the route-map logic.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_mcp_routes.py`:
+
+```python
+# Copyright 2026 SURF
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests that build_mcp exposes only the two GET /reservations operations."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client
+
+from aggregator_proxy.main import app
+from aggregator_proxy.mcp_server import build_mcp
+
+
+@pytest.fixture()
+def _mcp_disabled_auth(monkeypatch) -> None:
+    """Ensure auth flags are off so build_mcp can be constructed without OIDC config."""
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "auth_enabled", False)
+    monkeypatch.setattr(settings, "mcp_auth_enabled", False)
+
+
+async def test_only_get_reservations_are_exposed(_mcp_disabled_auth) -> None:
+    mcp = build_mcp(app)
+    async with Client(mcp) as client:
+        resources = await client.list_resources()
+        templates = await client.list_resource_templates()
+        tools = await client.list_tools()
+
+    resource_names = {r.name for r in resources}
+    template_names = {t.name for t in templates}
+    tool_names = {t.name for t in tools}
+
+    assert resource_names == {"list_reservations"}
+    assert template_names == {"get_reservation"}
+    assert tool_names == set(), f"expected no tools but got: {tool_names}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_mcp_routes.py -v`
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'aggregator_proxy.mcp_server'`.
+
+- [ ] **Step 3: Create `aggregator_proxy/mcp_server.py`**
+
+```python
+# Copyright 2026 SURF
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""FastMCP sub-app builder exposing GET /reservations as MCP Resources."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastmcp import FastMCP
+from fastmcp.server.providers.openapi import MCPType, RouteMap
+
+_DETAIL_PATTERN = r"^/reservations/\{[^}]+\}$"
+_LIST_PATTERN = r"^/reservations$"
+
+
+def build_mcp(api: FastAPI) -> FastMCP:
+    """Build a FastMCP server from the given FastAPI app, exposing only GET /reservations."""
+    return FastMCP.from_fastapi(
+        app=api,
+        name="NSI Aggregator Proxy",
+        route_maps=[
+            RouteMap(methods=["GET"], pattern=_DETAIL_PATTERN, mcp_type=MCPType.RESOURCE_TEMPLATE),
+            RouteMap(methods=["GET"], pattern=_LIST_PATTERN, mcp_type=MCPType.RESOURCE),
+            RouteMap(mcp_type=MCPType.EXCLUDE),
+        ],
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_mcp_routes.py -v`
+
+Expected: PASS. If the test fails because `Client(mcp).list_resources()` returns a wrapper object with a different shape, adjust the assertions — but the wrapper API documented in FastMCP 3.x returns `list[Resource]` with `.name` attributes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aggregator_proxy/mcp_server.py tests/test_mcp_routes.py
+git commit -m "Add build_mcp factory with route maps for read-only reservations"
+```
+
+---
+
+## Task 5: Add token forwarding event hook
+
+**Files:**
+- Modify: `aggregator_proxy/mcp_server.py`
+- Test: `tests/test_mcp_auth.py` (new file)
+
+When `auth_enabled=true`, the MCP-internal call must forward the MCP client's `Authorization` header so the existing `get_authenticated_user` dependency on `/reservations` re-validates.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_mcp_auth.py`:
+
+```python
+# Copyright 2026 SURF
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for MCP authentication wiring."""
+
+from __future__ import annotations
+
+import pytest
+
+from aggregator_proxy.main import app
+
+
+async def test_event_hook_registered_when_auth_enabled(monkeypatch) -> None:
+    """When auth_enabled=true, build_mcp must wire the token-forwarding event hook."""
+    from aggregator_proxy import mcp_server
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "auth_enabled", True)
+    monkeypatch.setattr(settings, "mcp_auth_enabled", False)
+
+    captured: dict = {}
+
+    real_from_fastapi = mcp_server.FastMCP.from_fastapi
+
+    def spy(*args, **kwargs):  # type: ignore[no-untyped-def]
+        captured["httpx_client_kwargs"] = kwargs.get("httpx_client_kwargs", {})
+        return real_from_fastapi(*args, **kwargs)
+
+    monkeypatch.setattr(mcp_server.FastMCP, "from_fastapi", spy)
+
+    mcp_server.build_mcp(app)
+
+    hooks = captured["httpx_client_kwargs"].get("event_hooks", {})
+    assert "request" in hooks, "expected request event hook to be registered"
+    assert len(hooks["request"]) == 1
+
+
+async def test_no_event_hook_when_auth_disabled(monkeypatch) -> None:
+    """When auth_enabled=false, no event hook is needed."""
+    from aggregator_proxy import mcp_server
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "auth_enabled", False)
+    monkeypatch.setattr(settings, "mcp_auth_enabled", False)
+
+    captured: dict = {}
+
+    real_from_fastapi = mcp_server.FastMCP.from_fastapi
+
+    def spy(*args, **kwargs):  # type: ignore[no-untyped-def]
+        captured["httpx_client_kwargs"] = kwargs.get("httpx_client_kwargs", {})
+        return real_from_fastapi(*args, **kwargs)
+
+    monkeypatch.setattr(mcp_server.FastMCP, "from_fastapi", spy)
+
+    mcp_server.build_mcp(app)
+
+    hooks = captured["httpx_client_kwargs"].get("event_hooks", {})
+    assert "request" not in hooks or not hooks["request"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_mcp_auth.py -v`
+
+Expected: FAIL — the spy captures empty `httpx_client_kwargs`.
+
+- [ ] **Step 3: Add token forwarding to `build_mcp`**
+
+Update `aggregator_proxy/mcp_server.py`:
+
+```python
+"""FastMCP sub-app builder exposing GET /reservations as MCP Resources."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from fastapi import FastAPI
+from fastmcp import FastMCP
+from fastmcp.server.context import request_ctx
+from fastmcp.server.providers.openapi import MCPType, RouteMap
+
+from aggregator_proxy.settings import settings
+
+_DETAIL_PATTERN = r"^/reservations/\{[^}]+\}$"
+_LIST_PATTERN = r"^/reservations$"
+
+
+async def _forward_user_token(request: httpx.Request) -> None:
+    """Copy the MCP client's Authorization header onto the internal /reservations call."""
+    ctx = request_ctx.get(None)
+    if ctx is None:
+        return
+    incoming = getattr(ctx, "request", None)
+    if incoming is None:
+        return
+    token = incoming.headers.get("authorization")
+    if token:
+        request.headers["Authorization"] = token
+
+
+def build_mcp(api: FastAPI) -> FastMCP:
+    """Build a FastMCP server from the given FastAPI app, exposing only GET /reservations."""
+    httpx_kwargs: dict[str, Any] = {}
+    if settings.auth_enabled:
+        httpx_kwargs["event_hooks"] = {"request": [_forward_user_token]}
+
+    return FastMCP.from_fastapi(
+        app=api,
+        name="NSI Aggregator Proxy",
+        route_maps=[
+            RouteMap(methods=["GET"], pattern=_DETAIL_PATTERN, mcp_type=MCPType.RESOURCE_TEMPLATE),
+            RouteMap(methods=["GET"], pattern=_LIST_PATTERN, mcp_type=MCPType.RESOURCE),
+            RouteMap(mcp_type=MCPType.EXCLUDE),
+        ],
+        httpx_client_kwargs=httpx_kwargs,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_mcp_auth.py tests/test_mcp_routes.py -v`
+
+Expected: all PASS — the route-filtering test from Task 4 still passes (no behavioral change when auth is off), and both new auth-hook tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aggregator_proxy/mcp_server.py tests/test_mcp_auth.py
+git commit -m "Forward MCP client Authorization header to internal /reservations call"
+```
+
+---
+
+## Task 6: Add MCP-level OIDC authentication
+
+**Files:**
+- Modify: `aggregator_proxy/mcp_server.py`
+- Test: `tests/test_mcp_auth.py` (append)
+
+When `mcp_auth_enabled=true`, the MCP server itself must validate the incoming JWT (independently of whatever forwarding happens to the internal call).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_mcp_auth.py`:
+
+```python
+async def test_mcp_has_auth_provider_when_mcp_auth_enabled(monkeypatch) -> None:
+    """When mcp_auth_enabled=true, the FastMCP server is configured with an auth provider."""
+    from aggregator_proxy import mcp_server
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "mcp_auth_enabled", True)
+    monkeypatch.setattr(settings, "auth_enabled", True)
+    monkeypatch.setattr(settings, "oidc_issuer", "https://idp.example.com")
+    monkeypatch.setattr(settings, "oidc_audience", "test-audience")
+    monkeypatch.setattr(settings, "oidc_jwks_uri", "https://idp.example.com/jwks")
+
+    mcp = mcp_server.build_mcp(app)
+
+    assert mcp.auth is not None, "expected MCP server to have an auth provider configured"
+
+
+async def test_mcp_has_no_auth_provider_when_mcp_auth_disabled(monkeypatch) -> None:
+    from aggregator_proxy import mcp_server
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "mcp_auth_enabled", False)
+    monkeypatch.setattr(settings, "auth_enabled", False)
+
+    mcp = mcp_server.build_mcp(app)
+
+    assert mcp.auth is None
+```
+
+(Note: `mcp.auth` is the documented attribute on FastMCP. If the attribute name differs in the installed version, adjust both assertions.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_mcp_auth.py -v -k auth_provider`
+
+Expected: FAIL — `mcp.auth` is `None` even when `mcp_auth_enabled=True`.
+
+- [ ] **Step 3: Wire OIDC auth in `build_mcp`**
+
+Update `aggregator_proxy/mcp_server.py` (add the auth construction):
+
+```python
+"""FastMCP sub-app builder exposing GET /reservations as MCP Resources."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from fastapi import FastAPI
+from fastmcp import FastMCP
+from fastmcp.server.auth import OAuthProvider
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+from fastmcp.server.context import request_ctx
+from fastmcp.server.providers.openapi import MCPType, RouteMap
+
+from aggregator_proxy.settings import settings
+
+_DETAIL_PATTERN = r"^/reservations/\{[^}]+\}$"
+_LIST_PATTERN = r"^/reservations$"
+
+
+async def _forward_user_token(request: httpx.Request) -> None:
+    """Copy the MCP client's Authorization header onto the internal /reservations call."""
+    ctx = request_ctx.get(None)
+    if ctx is None:
+        return
+    incoming = getattr(ctx, "request", None)
+    if incoming is None:
+        return
+    token = incoming.headers.get("authorization")
+    if token:
+        request.headers["Authorization"] = token
+
+
+def _build_auth() -> OAuthProvider | None:
+    """Build an MCP-level OIDC auth provider, or None if MCP auth is disabled."""
+    if not settings.mcp_auth_enabled:
+        return None
+    verifier = JWTVerifier(
+        jwks_uri=settings.oidc_jwks_uri,
+        issuer=settings.oidc_issuer,
+        audience=settings.oidc_audience,
+    )
+    return OAuthProvider(token_verifier=verifier)
+
+
+def build_mcp(api: FastAPI) -> FastMCP:
+    """Build a FastMCP server from the given FastAPI app, exposing only GET /reservations."""
+    httpx_kwargs: dict[str, Any] = {}
+    if settings.auth_enabled:
+        httpx_kwargs["event_hooks"] = {"request": [_forward_user_token]}
+
+    return FastMCP.from_fastapi(
+        app=api,
+        name="NSI Aggregator Proxy",
+        auth=_build_auth(),
+        route_maps=[
+            RouteMap(methods=["GET"], pattern=_DETAIL_PATTERN, mcp_type=MCPType.RESOURCE_TEMPLATE),
+            RouteMap(methods=["GET"], pattern=_LIST_PATTERN, mcp_type=MCPType.RESOURCE),
+            RouteMap(mcp_type=MCPType.EXCLUDE),
+        ],
+        httpx_client_kwargs=httpx_kwargs,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_mcp_auth.py tests/test_mcp_routes.py -v`
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aggregator_proxy/mcp_server.py tests/test_mcp_auth.py
+git commit -m "Wire OIDC JWT validation for MCP endpoint when mcp_auth_enabled=true"
+```
+
+---
+
+## Task 7: Mount MCP sub-app and add startup validation
+
+**Files:**
+- Modify: `aggregator_proxy/main.py`
+- Test: `tests/test_mcp_auth.py` (append)
+
+Mount the MCP sub-app on the FastAPI app, combine lifespans, and add the two startup-time validations.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_mcp_auth.py`:
+
+```python
+def test_startup_rejects_auth_enabled_without_mcp_auth(monkeypatch) -> None:
+    """If REST auth is on but MCP auth is off, startup must refuse."""
+    import importlib
+
+    monkeypatch.setenv("AGGREGATOR_PROXY_MCP_ENABLED", "true")
+    monkeypatch.setenv("AGGREGATOR_PROXY_AUTH_ENABLED", "true")
+    monkeypatch.setenv("AGGREGATOR_PROXY_MCP_AUTH_ENABLED", "false")
+    monkeypatch.setenv("AGGREGATOR_PROXY_OIDC_ISSUER", "https://idp.example.com")
+
+    from aggregator_proxy import main, settings as settings_mod
+    importlib.reload(settings_mod)
+    with pytest.raises(SystemExit):
+        importlib.reload(main)
+
+
+def test_startup_rejects_mcp_auth_without_explicit_jwks_uri(monkeypatch) -> None:
+    """MCP auth requires explicit OIDC_JWKS_URI (no lifespan auto-discovery available at module load)."""
+    import importlib
+
+    monkeypatch.setenv("AGGREGATOR_PROXY_MCP_ENABLED", "true")
+    monkeypatch.setenv("AGGREGATOR_PROXY_AUTH_ENABLED", "true")
+    monkeypatch.setenv("AGGREGATOR_PROXY_MCP_AUTH_ENABLED", "true")
+    monkeypatch.setenv("AGGREGATOR_PROXY_OIDC_ISSUER", "https://idp.example.com")
+    monkeypatch.delenv("AGGREGATOR_PROXY_OIDC_JWKS_URI", raising=False)
+
+    from aggregator_proxy import main, settings as settings_mod
+    importlib.reload(settings_mod)
+    with pytest.raises(SystemExit):
+        importlib.reload(main)
+
+
+def test_mcp_path_returns_404_when_disabled(monkeypatch) -> None:
+    """When mcp_enabled=false, the /mcp path is not mounted."""
+    from fastapi.testclient import TestClient
+
+    from aggregator_proxy.main import app
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "mcp_enabled", False)
+
+    with TestClient(app) as client:
+        response = client.get("/mcp")
+    assert response.status_code == 404
+```
+
+Note: the two startup-rejection tests use `importlib.reload` to re-run `aggregator_proxy.main` with new env vars. This is somewhat coupled to module-load behavior — if module reload turns out unreliable, an alternative is to factor the validation into a `validate_settings()` function in `main.py` and call it directly. Either approach is acceptable; the test simply needs to exercise both rejection paths.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_mcp_auth.py -v -k "startup or 404"`
+
+Expected: FAIL — `SystemExit` not raised; `/mcp` returns 404 only because nothing is mounted (this third test may already pass coincidentally, in which case keep it as a regression guard).
+
+- [ ] **Step 3: Add startup validation and mount logic to `aggregator_proxy/main.py`**
+
+At the bottom of `aggregator_proxy/main.py`, after the existing `app.include_router(...)` calls but before `def run()`, add:
+
+```python
+from fastmcp.utilities.lifespan import combine_lifespans  # noqa: E402
+
+from aggregator_proxy.mcp_server import build_mcp  # noqa: E402
+
+if settings.mcp_enabled:
+    if settings.auth_enabled and not settings.mcp_auth_enabled:
+        raise SystemExit(
+            "AGGREGATOR_PROXY_MCP_AUTH_ENABLED must be true when AGGREGATOR_PROXY_AUTH_ENABLED is true"
+        )
+    if settings.mcp_auth_enabled and not settings.oidc_jwks_uri:
+        raise SystemExit(
+            "AGGREGATOR_PROXY_OIDC_JWKS_URI must be set explicitly when MCP_AUTH_ENABLED is true"
+        )
+
+    mcp_app = build_mcp(app).http_app(path="/")
+    original_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = combine_lifespans(original_lifespan, mcp_app.lifespan)
+    app.mount(settings.mcp_path, mcp_app)
+```
+
+The `# noqa: E402` comments are because these imports are placed after module-level code, which ruff would otherwise flag.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_mcp_auth.py tests/test_mcp_routes.py -v`
+
+Expected: all PASS. Then run the full suite to check no regressions:
+
+Run: `uv run pytest -v`
+
+Expected: every existing test still passes. The MCP code only runs when `settings.mcp_enabled=true`, which is `False` by default in tests (conftest doesn't set it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aggregator_proxy/main.py tests/test_mcp_auth.py
+git commit -m "Mount MCP sub-app and add startup validation for auth coupling"
+```
+
+---
+
+## Task 8: End-to-end integration test
+
+**Files:**
+- Create: `tests/test_mcp_integration.py`
+
+Read both resources via `fastmcp.Client` against an in-process FastAPI app with a populated reservation store and mocked aggregator.
+
+- [ ] **Step 1: Write the integration test**
+
+Create `tests/test_mcp_integration.py`:
+
+```python
+# Copyright 2026 SURF
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""End-to-end MCP integration tests against the FastAPI app with a mocked aggregator."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+from fastmcp import Client
+
+from aggregator_proxy.main import app
+from aggregator_proxy.mcp_server import build_mcp
+from aggregator_proxy.nsi_soap import parse_correlation_id
+from aggregator_proxy.reservation_store import ReservationStore
+from tests.conftest import (
+    build_query_notification_sync_response,
+    build_query_summary_sync_response,
+    make_reservation,
+)
+
+
+CONNECTION_ID = "conn-int-001"
+
+
+def _mock_aggregator(connection_id: str) -> Callable[[httpx.Request], httpx.Response]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        cid = parse_correlation_id(request.content)
+        body = request.content.decode()
+        if "queryNotificationSync" in body:
+            return httpx.Response(200, content=build_query_notification_sync_response(cid))
+        return httpx.Response(
+            200,
+            content=build_query_summary_sync_response(
+                connection_id=connection_id, correlation_id=cid
+            ),
+        )
+
+    return handler
+
+
+@pytest.fixture()
+def _app_with_reservation(monkeypatch) -> None:
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "auth_enabled", False)
+    monkeypatch.setattr(settings, "mcp_auth_enabled", False)
+
+    store = ReservationStore()
+    store.create(make_reservation(connection_id=CONNECTION_ID, description="integration test"))
+    app.state.nsi_client = httpx.AsyncClient(transport=httpx.MockTransport(_mock_aggregator(CONNECTION_ID)))
+    app.state.callback_client = httpx.AsyncClient()
+    app.state.reservation_store = store
+
+
+async def test_list_reservations_via_mcp(_app_with_reservation) -> None:
+    mcp = build_mcp(app)
+    async with Client(mcp) as client:
+        # Discover the actual resource URI from the server rather than hardcoding it.
+        resources = await client.list_resources()
+        list_resource = next(r for r in resources if r.name == "list_reservations")
+        contents = await client.read_resource(list_resource.uri)
+
+    payload = json.loads(contents[0].text)
+    assert "reservations" in payload
+    ids = [r["connectionId"] for r in payload["reservations"]]
+    assert CONNECTION_ID in ids
+
+
+async def test_get_reservation_via_mcp(_app_with_reservation) -> None:
+    mcp = build_mcp(app)
+    async with Client(mcp) as client:
+        templates = await client.list_resource_templates()
+        get_template = next(t for t in templates if t.name == "get_reservation")
+        # uriTemplate has the form `.../{connectionId}` — fill it in.
+        uri = get_template.uriTemplate.replace("{connectionId}", CONNECTION_ID)
+        contents = await client.read_resource(uri)
+
+    payload = json.loads(contents[0].text)
+    assert payload["connectionId"] == CONNECTION_ID
+    assert payload["description"] == "integration test"
+
+
+async def test_get_reservation_unknown_id_errors(_app_with_reservation) -> None:
+    """A missing connection ID surfaces as an MCP error (not a silent empty result)."""
+    mcp = build_mcp(app)
+    async with Client(mcp) as client:
+        templates = await client.list_resource_templates()
+        get_template = next(t for t in templates if t.name == "get_reservation")
+        uri = get_template.uriTemplate.replace("{connectionId}", "does-not-exist")
+        with pytest.raises(Exception) as excinfo:
+            await client.read_resource(uri)
+    # The aggregator mock returns empty, so the underlying call yields 404.
+    # FastMCP wraps non-2xx in an error containing the status code or detail.
+    msg = str(excinfo.value)
+    assert "404" in msg or "not found" in msg.lower()
+```
+
+Note: `Resource` and `ResourceTemplate` field names (`uri`, `uriTemplate`) match the MCP protocol. If the installed FastMCP version exposes them under different attribute names (e.g., `uri_template`), adjust accordingly — the test discovers everything by inspection so a single attribute rename is the only fix needed.
+
+- [ ] **Step 2: Run the integration tests**
+
+Run: `uv run pytest tests/test_mcp_integration.py -v`
+
+Expected: PASS for `test_list_reservations_via_mcp` and `test_get_reservation_via_mcp`. The unknown-id test may need URI-pattern or error-message tuning.
+
+- [ ] **Step 3: Run the full suite to confirm no regressions**
+
+Run: `uv run pytest -v`
+
+Expected: all pass.
+
+- [ ] **Step 4: Run type check**
+
+Run: `uv run mypy aggregator_proxy`
+
+Expected: no errors. If `fastmcp` types are missing, add `fastmcp` to the `[[tool.mypy.overrides]]` `ignore_missing_imports` block in `pyproject.toml` (already global-ignored, so this should be fine).
+
+- [ ] **Step 5: Run linter**
+
+Run: `uv run ruff check . && uv run ruff format --check .`
+
+Expected: no issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_mcp_integration.py
+git commit -m "Add end-to-end MCP integration tests for resource reads"
+```
+
+---
+
+## Task 9: Update README and CLAUDE.md
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+Document the new feature and env vars.
+
+- [ ] **Step 1: Add MCP section to `README.md`**
+
+Insert a new `## MCP Endpoint (optional)` section after the Authentication section (search for `## API Endpoints` and place the MCP section directly before it):
+
+````markdown
+## MCP Endpoint (optional)
+
+The Aggregator Proxy can expose its read-only reservation endpoints as a [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server, mounted at `/mcp`. This lets AI agents (Claude Desktop, custom agents using `fastmcp.Client`, etc.) list and inspect reservations as MCP **Resources**.
+
+Only the two GET operations are exposed:
+
+- `GET /reservations` → MCP Resource `resource://list_reservations`
+- `GET /reservations/{connectionId}` → MCP ResourceTemplate `resource://get_reservation/{connectionId}`
+
+All state-changing operations (POST, DELETE) and the NSI callback endpoint are explicitly excluded from MCP.
+
+### Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `AGGREGATOR_PROXY_MCP_ENABLED` | `false` | Mount the MCP sub-app. Opt-in; the feature is disabled by default. |
+| `AGGREGATOR_PROXY_MCP_PATH` | `/mcp` | Mount path for the MCP sub-app. |
+| `AGGREGATOR_PROXY_MCP_AUTH_ENABLED` | `false` | Require an OIDC JWT on the MCP endpoint. Validated by FastMCP's `JWTVerifier` using the same `OIDC_*` settings as the REST endpoints. |
+
+**Startup validation:** when `AUTH_ENABLED=true`, `MCP_AUTH_ENABLED` must also be `true` — otherwise the proxy would expose authenticated data via an unauthenticated MCP endpoint. The proxy refuses to start in that configuration. Additionally, when `MCP_AUTH_ENABLED=true`, `OIDC_JWKS_URI` must be set explicitly (auto-discovery is not available at module load time).
+
+### Minimal client example
+
+```python
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+transport = StreamableHttpTransport(
+    url="https://proxy.example.com/mcp/",
+    headers={"Authorization": "Bearer <your-token>"},
+)
+
+async with Client(transport) as client:
+    contents = await client.read_resource("resource://list_reservations")
+    print(contents[0].text)
+```
+````
+
+- [ ] **Step 2: Add a paragraph to `CLAUDE.md`**
+
+In `CLAUDE.md`, under the "Key design points" section, append the following bullet after the existing "Dual-ingress authentication" bullet:
+
+```markdown
+- **Optional MCP sub-app**: when `MCP_ENABLED=true`, an `aggregator_proxy/mcp_server.py` factory builds a `FastMCP.from_fastapi()` sub-app mounted at `/mcp`. Route maps expose only `GET /reservations` (Resource) and `GET /reservations/{connectionId}` (ResourceTemplate); everything else is `MCPType.EXCLUDE`. The MCP-internal call to `/reservations` runs through the existing FastAPI handlers and dependencies, so no business logic is duplicated. When `auth_enabled=true`, an httpx event hook forwards the MCP client's `Authorization` header to the internal call so the existing `get_authenticated_user` dependency re-validates.
+```
+
+- [ ] **Step 3: Add the three new env vars to the CLAUDE.md configuration table**
+
+In `CLAUDE.md`'s "Configuration reference" table, add three rows (place them at the end of the table):
+
+```markdown
+| `AGGREGATOR_PROXY_MCP_ENABLED` | No | `false` | Mount the MCP sub-app at `MCP_PATH`. Off by default; opt-in. |
+| `AGGREGATOR_PROXY_MCP_PATH` | No | `/mcp` | Mount path for the MCP sub-app. |
+| `AGGREGATOR_PROXY_MCP_AUTH_ENABLED` | No | `false` | Require an OIDC JWT on the MCP endpoint. Validated by FastMCP's `JWTVerifier` using the same `OIDC_*` settings. Must be `true` whenever `AUTH_ENABLED=true`. |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CLAUDE.md
+git commit -m "Document MCP endpoint configuration and usage"
+```
+
+---
+
+## Final verification
+
+After all tasks are complete:
+
+- [ ] Run the full test suite: `uv run pytest -v`
+- [ ] Run type check: `uv run mypy aggregator_proxy`
+- [ ] Run lint: `uv run ruff check . && uv run ruff format --check .`
+- [ ] Sanity-start the server with MCP enabled:
+
+```bash
+AGGREGATOR_PROXY_PROVIDER_URL=https://aggregator.example.com/nsi-v2/ConnectionServiceProvider \
+  AGGREGATOR_PROXY_REQUESTER_NSA=urn:ogf:network:example.com:2025:requester-nsa \
+  AGGREGATOR_PROXY_PROVIDER_NSA=urn:ogf:network:example.com:2025:provider-nsa \
+  AGGREGATOR_PROXY_BASE_URL=https://proxy.example.com \
+  AGGREGATOR_PROXY_MCP_ENABLED=true \
+  uv run aggregator-proxy
+```
+
+Then in another shell, verify the MCP endpoint responds (an unauthenticated `GET /mcp/` should return an MCP error or info response — at minimum it shouldn't 404):
+
+```bash
+curl -i http://localhost:8080/mcp/
+```
+
+Expected: HTTP 200 (FastMCP info) or a documented MCP error — anything except 404 (which would mean the sub-app didn't mount).
+
+Stop the server with Ctrl-C.
+
+- [ ] Confirm the startup-validation paths by running the server with bad flags:
+
+```bash
+AGGREGATOR_PROXY_PROVIDER_URL=... \
+  AGGREGATOR_PROXY_REQUESTER_NSA=... \
+  AGGREGATOR_PROXY_PROVIDER_NSA=... \
+  AGGREGATOR_PROXY_BASE_URL=... \
+  AGGREGATOR_PROXY_AUTH_ENABLED=true \
+  AGGREGATOR_PROXY_OIDC_ISSUER=https://idp.example.com \
+  AGGREGATOR_PROXY_MCP_ENABLED=true \
+  AGGREGATOR_PROXY_MCP_AUTH_ENABLED=false \
+  uv run aggregator-proxy
+```
+
+Expected: the server exits immediately with the error `AGGREGATOR_PROXY_MCP_AUTH_ENABLED must be true when AGGREGATOR_PROXY_AUTH_ENABLED is true`.

--- a/docs/superpowers/specs/2026-05-20-mcp-reservations-endpoint-design.md
+++ b/docs/superpowers/specs/2026-05-20-mcp-reservations-endpoint-design.md
@@ -1,0 +1,232 @@
+# MCP Endpoint for Reservations — Design
+
+**Date:** 2026-05-20
+**Status:** Approved for implementation planning
+**Scope:** Add a Model Context Protocol (MCP) endpoint that exposes the two read-only `/reservations` operations of the NSI Aggregator Proxy to MCP clients (AI agents).
+
+## Goal
+
+Mount an MCP sub-app on the existing FastAPI application that exposes:
+
+- `GET /reservations` as an MCP **Resource**
+- `GET /reservations/{connectionId}` as an MCP **ResourceTemplate**
+
+All other routes (POST create, POST provision, POST release, DELETE terminate, the NSI callback, and health) must be invisible to MCP clients.
+
+Implemented using `FastMCP.from_fastapi()` with route maps, so the existing FastAPI handlers and their dependencies remain the single source of truth.
+
+## Non-goals
+
+- No state-changing MCP tools (no provision, release, terminate, or create via MCP).
+- No stdio transport. HTTP only.
+- No MCP-specific rate limiting, audit logging beyond what already exists, or scope-based authorization beyond presence of a valid OIDC token.
+- No changes to the simplified connection state machine, the SOAP layer, or the reservation store.
+
+## Components
+
+### New module — `aggregator_proxy/mcp_server.py`
+
+A single factory `build_mcp(api: FastAPI) -> FastMCP` that returns a configured `FastMCP` instance with route maps that keep only the two GET reservation paths and exclude everything else.
+
+```python
+from fastapi import FastAPI
+from fastmcp import FastMCP
+from fastmcp.server.auth import OAuthProvider
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+from fastmcp.server.context import request_ctx
+from fastmcp.server.providers.openapi import RouteMap, MCPType
+
+from aggregator_proxy.settings import settings
+
+_DETAIL_PATTERN = r"^/reservations/\{[^}]+\}$"
+_LIST_PATTERN = r"^/reservations$"
+
+async def _forward_user_token(request) -> None:
+    """Copy the MCP client's Authorization header onto the internal /reservations call."""
+    ctx = request_ctx.get(None)
+    if ctx is None:
+        return
+    incoming = getattr(ctx, "request", None)
+    if incoming is None:
+        return
+    token = incoming.headers.get("authorization")
+    if token:
+        request.headers["Authorization"] = token
+
+def build_mcp(api: FastAPI) -> FastMCP:
+    auth = None
+    if settings.mcp_auth_enabled:
+        auth = OAuthProvider(
+            token_verifier=JWTVerifier(
+                jwks_uri=settings.oidc_jwks_uri,
+                issuer=settings.oidc_issuer,
+                audience=settings.oidc_audience,
+            )
+        )
+    httpx_kwargs: dict = {}
+    if settings.auth_enabled:
+        httpx_kwargs["event_hooks"] = {"request": [_forward_user_token]}
+    return FastMCP.from_fastapi(
+        app=api,
+        name="NSI Aggregator Proxy",
+        auth=auth,
+        route_maps=[
+            RouteMap(methods=["GET"], pattern=_DETAIL_PATTERN, mcp_type=MCPType.RESOURCE_TEMPLATE),
+            RouteMap(methods=["GET"], pattern=_LIST_PATTERN, mcp_type=MCPType.RESOURCE),
+            RouteMap(mcp_type=MCPType.EXCLUDE),  # catch-all — hide everything else
+        ],
+        httpx_client_kwargs=httpx_kwargs,
+    )
+```
+
+### Modified `aggregator_proxy/main.py`
+
+Inside the existing `lifespan`, add the startup validation. After the existing `app.include_router(...)` calls, mount the MCP ASGI app:
+
+```python
+from fastmcp.utilities.lifespan import combine_lifespans
+from aggregator_proxy.mcp_server import build_mcp
+
+# Module level — startup-time validation (raised before uvicorn binds the port):
+if settings.mcp_enabled:
+    if settings.auth_enabled and not settings.mcp_auth_enabled:
+        raise SystemExit(
+            "AGGREGATOR_PROXY_MCP_AUTH_ENABLED must be true when AGGREGATOR_PROXY_AUTH_ENABLED is true"
+        )
+    if settings.mcp_auth_enabled and not settings.oidc_jwks_uri:
+        raise SystemExit(
+            "AGGREGATOR_PROXY_OIDC_JWKS_URI must be set explicitly when MCP_AUTH_ENABLED is true"
+        )
+
+# Module level — after include_router calls, before serving:
+if settings.mcp_enabled:
+    mcp_app = build_mcp(app).http_app(path="/")
+    original_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = combine_lifespans(original_lifespan, mcp_app.lifespan)
+    app.mount(settings.mcp_path, mcp_app)
+```
+
+Note: the `combine_lifespans` call replaces `lifespan_context` so the existing lifespan still runs; `mcp_app.lifespan` adds FastMCP's session-store startup/shutdown. Mutating `lifespan_context` after construction is the cleanest pattern given the chicken-and-egg between `FastMCP.from_fastapi(app)` needing the app and `FastAPI(lifespan=...)` needing the combined lifespan; an equivalent refactor that defers `FastAPI` construction until after MCP is built is acceptable too.
+
+### Modified `aggregator_proxy/settings.py`
+
+New settings (all optional, default off so the feature is opt-in):
+
+```python
+mcp_enabled: bool = False     # Mount the MCP sub-app
+mcp_path: str = "/mcp"        # Mount path
+mcp_auth_enabled: bool = False  # Require OIDC at the MCP layer
+```
+
+These follow the existing `AGGREGATOR_PROXY_` env-var convention.
+
+### Modified `aggregator_proxy/routers/reservations.py`
+
+Add explicit `operation_id` to the two GET routes so MCP component names are clean:
+
+- `GET /reservations` → `operation_id="list_reservations"`
+- `GET /reservations/{connectionId}` → `operation_id="get_reservation"`
+
+No other handler changes.
+
+### Modified `pyproject.toml`
+
+Add `fastmcp` (latest stable 3.x) to `[project.dependencies]`. Pin to a specific minor version per the project's existing strict-pin style (e.g. `fastmcp==3.2.4`).
+
+## Authentication model
+
+| `auth_enabled` | `mcp_auth_enabled` | Behavior |
+|---|---|---|
+| false | false | Everything open. MCP and REST both unauthenticated. |
+| false | true | MCP requires OIDC. Internal call to `/reservations` runs without auth (dependency is permissive). |
+| true | true | MCP requires OIDC; user's `Authorization` header forwarded by the httpx event hook to the internal `/reservations` call. Existing `get_authenticated_user` dependency re-validates. |
+| true | false | **Rejected at startup.** Would let MCP leak authenticated data. `SystemExit` raised. |
+
+The forwarding hook is only registered when `auth_enabled=true`; when REST auth is off, no forwarding happens (no header to forward, no need to add headers).
+
+OIDC settings (`oidc_issuer`, `oidc_audience`, `oidc_jwks_uri`) are reused — there is one OIDC identity provider for the whole proxy. We do not introduce a separate OIDC config for MCP.
+
+**Constraint: explicit `oidc_jwks_uri` required when `mcp_auth_enabled=true`.** The existing OIDC auto-discovery runs inside `lifespan` (after `httpx.AsyncClient` is available), but the MCP server is constructed at module load — before any discovery has happened. To avoid duplicating the discovery logic or delaying MCP mount, we require `AGGREGATOR_PROXY_OIDC_JWKS_URI` to be set explicitly when `mcp_auth_enabled=true`. Validated at startup with a clear `SystemExit` if missing. (The REST-side auth retains its existing auto-discovery behavior unchanged.)
+
+## MCP component naming
+
+| FastAPI route | MCP component | URI / Name |
+|---|---|---|
+| `GET /reservations` | Resource | `resource://list_reservations` (name from `operation_id`) |
+| `GET /reservations/{connectionId}` | ResourceTemplate | `resource://get_reservation/{connectionId}` |
+
+The existing `detail` query parameter (`summary` \| `full` \| `recursive`) is preserved automatically by `from_fastapi`, derived from the route's signature.
+
+## Errors
+
+`aggregator_error_handler` (502 on `httpx.HTTPStatusError`) is already registered on the FastAPI app and fires on the MCP-internal call. FastMCP surfaces non-2xx responses from the internal client as MCP protocol errors with the JSON body as the message. No new error handling is required.
+
+Specifically:
+- 404 from `GET /reservations/{connectionId}` → MCP resource read error with the JSON `{"detail": "..."}` body
+- 502 (aggregator unreachable) → MCP error surfacing the proxy's 502 body
+- 400 (`detail=recursive` on list) → MCP error (list endpoint rejects recursive)
+
+## Testing
+
+Three new test files, all using the existing pytest setup (`pytest-asyncio` auto mode + `pytest-httpx` for mocking outbound NSI calls):
+
+### `tests/test_mcp_routes.py`
+- After `build_mcp(app)`, assert the resource list contains exactly `list_reservations`
+- Assert the resource-template list contains exactly `get_reservation`
+- Assert the tool list is empty (no POST/DELETE exposed)
+
+### `tests/test_mcp_integration.py`
+- Spin up the FastAPI app with `mcp_enabled=true`, populate the in-memory store via `make_reservation`, mock the aggregator's `querySummarySync`/`queryNotificationSync` with `pytest-httpx`
+- Use `fastmcp.Client` against an in-process ASGI transport; call `list_resources()`, `read_resource("resource://list_reservations")`, and `read_resource("resource://get_reservation/<id>")`
+- Verify the `detail=full` parameter works and returns segments
+- Verify a non-existent connection ID surfaces as an MCP error
+
+### `tests/test_mcp_auth.py`
+- Startup-validation: `auth_enabled=true, mcp_auth_enabled=false, mcp_enabled=true` raises `SystemExit`
+- Startup-validation: `mcp_auth_enabled=true, oidc_jwks_uri=""` raises `SystemExit`
+- Token-forwarding: with both flags on, a request to MCP with a Bearer token is propagated to the internal `/reservations` call (assert via a captured request on the httpx mock)
+- No-MCP: with `mcp_enabled=false`, the `/mcp` path returns 404 (sub-app not mounted)
+
+## Documentation
+
+- **`README.md`**: add a short MCP section after the auth section, describing the two new env vars and showing a minimal `fastmcp.Client` example
+- **`CLAUDE.md`**: add a short paragraph in the "Key design points" section noting the optional MCP sub-app and how route maps filter it to read-only reservations endpoints
+- **`chart/values.yaml`**: no schema change needed — the existing `env` and `envFromSecret` map already supports `AGGREGATOR_PROXY_MCP_*` variables; add commented examples
+
+## Sequence diagram — authenticated MCP read
+
+```
+AI Agent           MCP layer (FastMCP)        FastAPI /reservations          Aggregator
+  |                       |                            |                          |
+  |--read_resource------->|                            |                          |
+  |  + Bearer JWT         |                            |                          |
+  |                       |--validate JWT (JWKS)------>|                          |
+  |                       |   (JWTVerifier)            |                          |
+  |                       |--internal httpx call------>|                          |
+  |                       |  + forwarded Authorization |                          |
+  |                       |                            |--get_authenticated_user->|
+  |                       |                            |  (re-validates same JWT) |
+  |                       |                            |--querySummarySync------->|
+  |                       |                            |<-querySummarySyncConfirmed
+  |                       |                            |--queryNotificationSync-->|
+  |                       |                            |<-queryNotificationSyncConfirmed
+  |                       |<--ReservationDetail JSON---|                          |
+  |<--Resource contents---|                            |                          |
+```
+
+## Open questions / future work
+
+- **Resource updates / subscriptions** — MCP supports resource subscriptions (notifications on change). The current design does not implement these; a future iteration could push notifications when the in-memory store changes.
+- **Tool exposure for state-changing ops** — explicitly out of scope for this design; if requested later, would require a new design pass on async-callback handling (the 202 + callback pattern doesn't map cleanly to synchronous MCP tools).
+- **Per-tool/per-resource scopes** — `mcp_auth_enabled` is binary today. Could later add scope checks (e.g., `read:reservations`) via FastMCP's `require_scopes` decorator.
+
+## Decision log
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| MCP scope | Read-only (the two GETs) | User explicitly requested read-only |
+| Library | Official `fastmcp` via `from_fastapi()` with route maps | User specified; minimal hand-written glue; reuses existing FastAPI handlers as the source of truth |
+| Resource vs Tool | Resource + ResourceTemplate | MCP-idiomatic for GET endpoints; future-proof if subscriptions added |
+| Auth coupling | "MCP stricter only" with token forwarding | Avoids introducing a new internal credential type; existing auth model unchanged |
+| Mount path | `/mcp` (configurable via `mcp_path`) | Conventional MCP path; configurable for proxy/ingress flexibility |
+| Default state | `mcp_enabled=false` | Opt-in; no behavior change for existing deployments |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ maintainers = [
 requires-python = ">=3.13"
 dependencies = [
     "fastapi[standard]==0.136.1",
+    "fastmcp==3.2.4",
     "httpx==0.28.1",
     "lxml==6.1.0",
     "pydantic-settings==2.14.1",

--- a/tests/test_get_reservations.py
+++ b/tests/test_get_reservations.py
@@ -344,3 +344,12 @@ class TestListReservationsDetailParameter:
         assert resp.status_code == 200
         for r in resp.json()["reservations"]:
             assert r["segments"] is None
+
+
+def test_reservation_get_routes_have_explicit_operation_ids() -> None:
+    """Operation IDs are used as MCP component names and must be stable, clean strings."""
+    schema = app.openapi()
+    list_op = schema["paths"]["/reservations"]["get"]["operationId"]
+    detail_op = schema["paths"]["/reservations/{connectionId}"]["get"]["operationId"]
+    assert list_op == "list_reservations"
+    assert detail_op == "get_reservation"

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -1,0 +1,64 @@
+# Copyright 2026 SURF
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for MCP authentication wiring."""
+
+from __future__ import annotations
+
+import pytest
+
+from aggregator_proxy.main import app
+
+
+async def test_event_hook_registered_when_auth_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When auth_enabled=true, build_mcp must wire the token-forwarding event hook."""
+    from aggregator_proxy import mcp_server
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "auth_enabled", True)
+    monkeypatch.setattr(settings, "mcp_auth_enabled", False)
+
+    captured: dict = {}
+
+    real_from_fastapi = mcp_server.FastMCP.from_fastapi
+
+    def spy(*args, **kwargs):  # type: ignore[no-untyped-def]
+        captured["httpx_client_kwargs"] = kwargs.get("httpx_client_kwargs", {})
+        return real_from_fastapi(*args, **kwargs)
+
+    monkeypatch.setattr(mcp_server.FastMCP, "from_fastapi", spy)
+
+    mcp_server.build_mcp(app)
+
+    hooks = captured["httpx_client_kwargs"].get("event_hooks", {})
+    assert "request" in hooks, "expected request event hook to be registered"
+    assert len(hooks["request"]) == 1
+
+
+async def test_no_event_hook_when_auth_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When auth_enabled=false, no event hook is needed."""
+    from aggregator_proxy import mcp_server
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "auth_enabled", False)
+    monkeypatch.setattr(settings, "mcp_auth_enabled", False)
+
+    captured: dict = {}
+
+    real_from_fastapi = mcp_server.FastMCP.from_fastapi
+
+    def spy(*args, **kwargs):  # type: ignore[no-untyped-def]
+        captured["httpx_client_kwargs"] = kwargs.get("httpx_client_kwargs", {})
+        return real_from_fastapi(*args, **kwargs)
+
+    monkeypatch.setattr(mcp_server.FastMCP, "from_fastapi", spy)
+
+    mcp_server.build_mcp(app)
+
+    hooks = captured["httpx_client_kwargs"].get("event_hooks", {})
+    assert "request" not in hooks or not hooks["request"]

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -5,6 +5,13 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 """Tests for MCP authentication wiring."""
 

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -210,6 +210,25 @@ def test_startup_rejects_mcp_auth_without_explicit_jwks_uri(monkeypatch: pytest.
         _validate_mcp_settings()
 
 
+def test_startup_rejects_mcp_auth_with_required_groups(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MCP auth with non-empty OIDC_REQUIRED_GROUPS is rejected because group checks cannot succeed.
+
+    JWTVerifier doesn't call userinfo, and the token-forwarding hook only forwards
+    ``Authorization`` — not ``X-Auth-Request-Access-Token``. ``get_authenticated_user``
+    would always 401 on the internal call, so fail at startup with a clear message.
+    """
+    from aggregator_proxy.main import _validate_mcp_settings
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "auth_enabled", True)
+    monkeypatch.setattr(settings, "mcp_auth_enabled", True)
+    monkeypatch.setattr(settings, "oidc_jwks_uri", "https://idp.example.com/jwks")
+    monkeypatch.setattr(settings, "oidc_required_groups", ["urn:example:group"])
+
+    with pytest.raises(SystemExit, match="AGGREGATOR_PROXY_OIDC_REQUIRED_GROUPS"):
+        _validate_mcp_settings()
+
+
 def test_validate_mcp_settings_accepts_valid_config(monkeypatch: pytest.MonkeyPatch) -> None:
     """When auth_enabled, mcp_auth_enabled, and oidc_jwks_uri are all set, validation passes."""
     from aggregator_proxy.main import _validate_mcp_settings
@@ -218,6 +237,7 @@ def test_validate_mcp_settings_accepts_valid_config(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(settings, "auth_enabled", True)
     monkeypatch.setattr(settings, "mcp_auth_enabled", True)
     monkeypatch.setattr(settings, "oidc_jwks_uri", "https://idp.example.com/jwks")
+    monkeypatch.setattr(settings, "oidc_required_groups", [])
 
     _validate_mcp_settings()
 

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -196,7 +196,6 @@ def test_startup_rejects_mcp_auth_without_explicit_jwks_uri(monkeypatch: pytest.
     from aggregator_proxy.main import _validate_mcp_settings
     from aggregator_proxy.settings import settings
 
-    monkeypatch.setattr(settings, "auth_enabled", True)
     monkeypatch.setattr(settings, "mcp_auth_enabled", True)
     monkeypatch.setattr(settings, "oidc_jwks_uri", "")
 
@@ -219,8 +218,6 @@ def test_validate_mcp_settings_accepts_valid_config(monkeypatch: pytest.MonkeyPa
 def test_mcp_path_returns_404_when_disabled() -> None:
     """When mcp_enabled=false (the default in tests), the /mcp path is not mounted."""
     from fastapi.testclient import TestClient
-
-    from aggregator_proxy.main import app
 
     with TestClient(app) as client:
         response = client.get("/mcp")

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -154,6 +154,9 @@ async def test_mcp_has_auth_provider_when_mcp_auth_enabled(monkeypatch: pytest.M
     mcp = mcp_server.build_mcp(app)
 
     assert mcp.auth is not None, "expected MCP server to have an auth provider configured"
+    assert mcp.auth.jwks_uri == "https://idp.example.com/jwks"
+    assert mcp.auth.issuer == "https://idp.example.com"
+    assert mcp.auth.audience == "test-audience"
 
 
 async def test_mcp_has_no_auth_provider_when_mcp_auth_disabled(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -10,6 +10,9 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import httpx
 import pytest
 
 from aggregator_proxy.main import app
@@ -62,3 +65,76 @@ async def test_no_event_hook_when_auth_disabled(monkeypatch: pytest.MonkeyPatch)
 
     hooks = captured["httpx_client_kwargs"].get("event_hooks", {})
     assert "request" not in hooks or not hooks["request"]
+
+
+async def test_forward_user_token_no_mcp_context_leaves_request_unchanged() -> None:
+    """When no MCP request context is in flight, the hook is a no-op."""
+    from aggregator_proxy.mcp_server import _forward_user_token
+
+    outgoing = httpx.Request("GET", "http://example.com")
+    original_headers = dict(outgoing.headers)
+
+    await _forward_user_token(outgoing)
+
+    assert dict(outgoing.headers) == original_headers
+    assert "Authorization" not in outgoing.headers
+
+
+async def test_forward_user_token_missing_incoming_request_leaves_request_unchanged() -> None:
+    """When the MCP context exists but has no .request attribute, the hook is a no-op."""
+    from fastmcp.server.context import request_ctx
+
+    from aggregator_proxy.mcp_server import _forward_user_token
+
+    fake_ctx = SimpleNamespace(request=None)
+    token_obj = request_ctx.set(fake_ctx)
+    try:
+        outgoing = httpx.Request("GET", "http://example.com")
+        original_headers = dict(outgoing.headers)
+
+        await _forward_user_token(outgoing)
+
+        assert dict(outgoing.headers) == original_headers
+        assert "Authorization" not in outgoing.headers
+    finally:
+        request_ctx.reset(token_obj)
+
+
+async def test_forward_user_token_missing_authorization_header_leaves_request_unchanged() -> None:
+    """When the incoming MCP request has no Authorization header, the hook is a no-op."""
+    from fastmcp.server.context import request_ctx
+
+    from aggregator_proxy.mcp_server import _forward_user_token
+
+    incoming = SimpleNamespace(headers={})
+    fake_ctx = SimpleNamespace(request=incoming)
+    token_obj = request_ctx.set(fake_ctx)
+    try:
+        outgoing = httpx.Request("GET", "http://example.com")
+        original_headers = dict(outgoing.headers)
+
+        await _forward_user_token(outgoing)
+
+        assert dict(outgoing.headers) == original_headers
+        assert "Authorization" not in outgoing.headers
+    finally:
+        request_ctx.reset(token_obj)
+
+
+async def test_forward_user_token_copies_authorization_header() -> None:
+    """When the incoming MCP request has an Authorization header, it is copied onto the outgoing request."""
+    from fastmcp.server.context import request_ctx
+
+    from aggregator_proxy.mcp_server import _forward_user_token
+
+    incoming = SimpleNamespace(headers={"authorization": "Bearer test-token"})
+    fake_ctx = SimpleNamespace(request=incoming)
+    token_obj = request_ctx.set(fake_ctx)
+    try:
+        outgoing = httpx.Request("GET", "http://example.com")
+
+        await _forward_user_token(outgoing)
+
+        assert outgoing.headers["Authorization"] == "Bearer test-token"
+    finally:
+        request_ctx.reset(token_obj)

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -138,3 +138,32 @@ async def test_forward_user_token_copies_authorization_header() -> None:
         assert outgoing.headers["Authorization"] == "Bearer test-token"
     finally:
         request_ctx.reset(token_obj)
+
+
+async def test_mcp_has_auth_provider_when_mcp_auth_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When mcp_auth_enabled=true, the FastMCP server is configured with an auth provider."""
+    from aggregator_proxy import mcp_server
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "mcp_auth_enabled", True)
+    monkeypatch.setattr(settings, "auth_enabled", True)
+    monkeypatch.setattr(settings, "oidc_issuer", "https://idp.example.com")
+    monkeypatch.setattr(settings, "oidc_audience", "test-audience")
+    monkeypatch.setattr(settings, "oidc_jwks_uri", "https://idp.example.com/jwks")
+
+    mcp = mcp_server.build_mcp(app)
+
+    assert mcp.auth is not None, "expected MCP server to have an auth provider configured"
+
+
+async def test_mcp_has_no_auth_provider_when_mcp_auth_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When mcp_auth_enabled=false, the FastMCP server has no auth provider."""
+    from aggregator_proxy import mcp_server
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "mcp_auth_enabled", False)
+    monkeypatch.setattr(settings, "auth_enabled", False)
+
+    mcp = mcp_server.build_mcp(app)
+
+    assert mcp.auth is None

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -170,3 +170,58 @@ async def test_mcp_has_no_auth_provider_when_mcp_auth_disabled(monkeypatch: pyte
     mcp = mcp_server.build_mcp(app)
 
     assert mcp.auth is None
+
+
+def test_startup_rejects_auth_enabled_without_mcp_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If REST auth is on but MCP auth is off, startup must refuse.
+
+    We call ``_validate_mcp_settings`` directly rather than reloading the
+    ``aggregator_proxy.main`` module: ``importlib.reload`` replaces the global
+    ``settings`` instance and ``app`` object, but the routers (imported once at
+    module load) keep references to the original ``settings`` instance, which
+    causes hard-to-debug test pollution across the suite.
+    """
+    from aggregator_proxy.main import _validate_mcp_settings
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "auth_enabled", True)
+    monkeypatch.setattr(settings, "mcp_auth_enabled", False)
+
+    with pytest.raises(SystemExit, match="AGGREGATOR_PROXY_MCP_AUTH_ENABLED"):
+        _validate_mcp_settings()
+
+
+def test_startup_rejects_mcp_auth_without_explicit_jwks_uri(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MCP auth requires explicit OIDC_JWKS_URI (no lifespan auto-discovery available at module load)."""
+    from aggregator_proxy.main import _validate_mcp_settings
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "auth_enabled", True)
+    monkeypatch.setattr(settings, "mcp_auth_enabled", True)
+    monkeypatch.setattr(settings, "oidc_jwks_uri", "")
+
+    with pytest.raises(SystemExit, match="AGGREGATOR_PROXY_OIDC_JWKS_URI"):
+        _validate_mcp_settings()
+
+
+def test_validate_mcp_settings_accepts_valid_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When auth_enabled, mcp_auth_enabled, and oidc_jwks_uri are all set, validation passes."""
+    from aggregator_proxy.main import _validate_mcp_settings
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "auth_enabled", True)
+    monkeypatch.setattr(settings, "mcp_auth_enabled", True)
+    monkeypatch.setattr(settings, "oidc_jwks_uri", "https://idp.example.com/jwks")
+
+    _validate_mcp_settings()
+
+
+def test_mcp_path_returns_404_when_disabled() -> None:
+    """When mcp_enabled=false (the default in tests), the /mcp path is not mounted."""
+    from fastapi.testclient import TestClient
+
+    from aggregator_proxy.main import app
+
+    with TestClient(app) as client:
+        response = client.get("/mcp")
+    assert response.status_code == 404

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -23,6 +23,7 @@ from collections.abc import Callable
 import httpx
 import pytest
 from fastmcp import Client
+from fastmcp.exceptions import McpError
 
 from aggregator_proxy.main import app
 from aggregator_proxy.mcp_server import build_mcp
@@ -102,7 +103,7 @@ async def test_get_reservation_unknown_id_errors(_app_with_reservation: None) ->
         templates = await client.list_resource_templates()
         get_template = next(t for t in templates if t.name == "get_reservation")
         uri = get_template.uriTemplate.replace("{connectionId}", "does-not-exist")
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(McpError) as excinfo:
             await client.read_resource(uri)
     msg = str(excinfo.value)
     assert "404" in msg or "not found" in msg.lower()

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -1,0 +1,108 @@
+# Copyright 2026 SURF
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""End-to-end MCP integration tests against the FastAPI app with a mocked aggregator."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+from fastmcp import Client
+
+from aggregator_proxy.main import app
+from aggregator_proxy.mcp_server import build_mcp
+from aggregator_proxy.nsi_soap import parse_correlation_id
+from aggregator_proxy.reservation_store import ReservationStore
+from tests.conftest import (
+    build_empty_query_summary_sync_response,
+    build_query_notification_sync_response,
+    build_query_summary_sync_response,
+    make_reservation,
+)
+
+CONNECTION_ID = "conn-int-001"
+
+
+def _mock_aggregator(connection_id: str) -> Callable[[httpx.Request], httpx.Response]:
+    def handler(request: httpx.Request) -> httpx.Response:
+        cid = parse_correlation_id(request.content)
+        body = request.content.decode()
+        if "queryNotificationSync" in body:
+            return httpx.Response(200, content=build_query_notification_sync_response(cid))
+        # If the SOAP request asks for a specific connectionId that isn't ours, return empty.
+        if f"<connectionId>{connection_id}</connectionId>" not in body and "<connectionId>" in body:
+            return httpx.Response(200, content=build_empty_query_summary_sync_response(cid))
+        return httpx.Response(
+            200,
+            content=build_query_summary_sync_response(connection_id=connection_id, correlation_id=cid),
+        )
+
+    return handler
+
+
+@pytest.fixture()
+def _app_with_reservation(monkeypatch: pytest.MonkeyPatch) -> None:
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "auth_enabled", False)
+    monkeypatch.setattr(settings, "mcp_auth_enabled", False)
+
+    store = ReservationStore()
+    store.create(make_reservation(connection_id=CONNECTION_ID, description="integration test"))
+    app.state.nsi_client = httpx.AsyncClient(transport=httpx.MockTransport(_mock_aggregator(CONNECTION_ID)))
+    app.state.callback_client = httpx.AsyncClient()
+    app.state.reservation_store = store
+
+
+async def test_list_reservations_via_mcp(_app_with_reservation: None) -> None:
+    mcp = build_mcp(app)
+    async with Client(mcp) as client:
+        resources = await client.list_resources()
+        list_resource = next(r for r in resources if r.name == "list_reservations")
+        contents = await client.read_resource(list_resource.uri)
+
+    payload = json.loads(contents[0].text)
+    assert "reservations" in payload
+    ids = [r["connectionId"] for r in payload["reservations"]]
+    assert CONNECTION_ID in ids
+
+
+async def test_get_reservation_via_mcp(_app_with_reservation: None) -> None:
+    mcp = build_mcp(app)
+    async with Client(mcp) as client:
+        templates = await client.list_resource_templates()
+        get_template = next(t for t in templates if t.name == "get_reservation")
+        uri = get_template.uriTemplate.replace("{connectionId}", CONNECTION_ID)
+        contents = await client.read_resource(uri)
+
+    payload = json.loads(contents[0].text)
+    assert payload["connectionId"] == CONNECTION_ID
+    assert payload["description"] == "integration test"
+
+
+async def test_get_reservation_unknown_id_errors(_app_with_reservation: None) -> None:
+    """A missing connection ID surfaces as an MCP error (not a silent empty result)."""
+    mcp = build_mcp(app)
+    async with Client(mcp) as client:
+        templates = await client.list_resource_templates()
+        get_template = next(t for t in templates if t.name == "get_reservation")
+        uri = get_template.uriTemplate.replace("{connectionId}", "does-not-exist")
+        with pytest.raises(Exception) as excinfo:
+            await client.read_resource(uri)
+    msg = str(excinfo.value)
+    assert "404" in msg or "not found" in msg.lower()

--- a/tests/test_mcp_routes.py
+++ b/tests/test_mcp_routes.py
@@ -5,6 +5,13 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 """Tests that build_mcp exposes only the two GET /reservations operations."""
 

--- a/tests/test_mcp_routes.py
+++ b/tests/test_mcp_routes.py
@@ -1,0 +1,42 @@
+# Copyright 2026 SURF
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests that build_mcp exposes only the two GET /reservations operations."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client
+
+from aggregator_proxy.main import app
+from aggregator_proxy.mcp_server import build_mcp
+
+
+@pytest.fixture()
+def _mcp_disabled_auth(monkeypatch) -> None:
+    """Ensure auth flags are off so build_mcp can be constructed without OIDC config."""
+    from aggregator_proxy.settings import settings
+
+    monkeypatch.setattr(settings, "auth_enabled", False)
+    monkeypatch.setattr(settings, "mcp_auth_enabled", False)
+
+
+async def test_only_get_reservations_are_exposed(_mcp_disabled_auth) -> None:
+    mcp = build_mcp(app)
+    async with Client(mcp) as client:
+        resources = await client.list_resources()
+        templates = await client.list_resource_templates()
+        tools = await client.list_tools()
+
+    resource_names = {r.name for r in resources}
+    template_names = {t.name for t in templates}
+    tool_names = {t.name for t in tools}
+
+    assert resource_names == {"list_reservations"}
+    assert template_names == {"get_reservation"}
+    assert tool_names == set(), f"expected no tools but got: {tool_names}"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -94,3 +94,23 @@ def test_env_file_read_as_utf8(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
 def test_env_file_encoding_configured() -> None:
     """The Settings model is configured to read env files as UTF-8."""
     assert Settings.model_config.get("env_file_encoding") == "utf-8"
+
+
+def test_mcp_settings_defaults() -> None:
+    """MCP settings default to disabled with the standard /mcp path."""
+    s = Settings()  # type: ignore[call-arg]
+    assert s.mcp_enabled is False
+    assert s.mcp_path == "/mcp"
+    assert s.mcp_auth_enabled is False
+
+
+def test_mcp_settings_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MCP settings can be overridden via AGGREGATOR_PROXY_MCP_* env vars."""
+    monkeypatch.setenv("AGGREGATOR_PROXY_MCP_ENABLED", "true")
+    monkeypatch.setenv("AGGREGATOR_PROXY_MCP_PATH", "/custom-mcp")
+    monkeypatch.setenv("AGGREGATOR_PROXY_MCP_AUTH_ENABLED", "true")
+
+    s = Settings()  # type: ignore[call-arg]
+    assert s.mcp_enabled is True
+    assert s.mcp_path == "/custom-mcp"
+    assert s.mcp_auth_enabled is True

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -114,3 +114,24 @@ def test_mcp_settings_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert s.mcp_enabled is True
     assert s.mcp_path == "/custom-mcp"
     assert s.mcp_auth_enabled is True
+
+
+def test_mcp_path_requires_leading_slash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MCP_PATH without a leading slash is rejected so app.mount behaves predictably."""
+    monkeypatch.setenv("AGGREGATOR_PROXY_MCP_PATH", "mcp")
+    with pytest.raises(ValueError, match="MCP_PATH must start with '/'"):
+        Settings()  # type: ignore[call-arg]
+
+
+def test_mcp_path_rejects_trailing_slash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MCP_PATH with a trailing slash is rejected to avoid mount-path ambiguity."""
+    monkeypatch.setenv("AGGREGATOR_PROXY_MCP_PATH", "/mcp/")
+    with pytest.raises(ValueError, match="MCP_PATH must not end with '/'"):
+        Settings()  # type: ignore[call-arg]
+
+
+def test_mcp_path_root_slash_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bare '/' is accepted (mounting at root); only longer paths must lack a trailing slash."""
+    monkeypatch.setenv("AGGREGATOR_PROXY_MCP_PATH", "/")
+    s = Settings()  # type: ignore[call-arg]
+    assert s.mcp_path == "/"

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,7 @@ version = "0.3.1.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "fastmcp" },
     { name = "httpx" },
     { name = "lxml" },
     { name = "pydantic-settings" },
@@ -34,6 +35,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "==0.136.1" },
+    { name = "fastmcp", specifier = "==3.2.4" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "lxml", specifier = "==6.1.0" },
     { name = "pydantic-settings", specifier = "==2.14.1" },
@@ -50,6 +52,18 @@ dev = [
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-httpx", specifier = "==0.36.2" },
     { name = "ruff", specifier = "==0.15.12" },
+]
+
+[[package]]
+name = "aiofile"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/cd/0d76dfc5de72bde52f55f53e925c7d152d9c7906634ec1e0cbc7e8d4ad93/aiofile-3.11.1-py3-none-any.whl", hash = "sha256:ce77d14ac07f77bc2b757834a5c129321f3f705c474593deed5ab209079a52c9", size = 20446, upload-time = "2026-05-16T08:18:32.051Z" },
 ]
 
 [[package]]
@@ -120,6 +134,63 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
     { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
     { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/c1/67cfb86aa21144796ff51068326d467fbef8ee42f8d08a3a8a926106cf0c/cachetools-7.1.3.tar.gz", hash = "sha256:135cfe944bc3c1e805505f65dae0bef375a2f96261171ab66c79ef77d0bda39d", size = 45780, upload-time = "2026-05-18T18:21:03.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/52/8ff5c1a3b2e821ced9b2998fba3ee29aa4525c0bf51e5ee55dd6f61a4ed5/cachetools-7.1.3-py3-none-any.whl", hash = "sha256:9876787e2346e20584d5cca236cb5d49d04e7193de91646f230725b2e1e8b804", size = 16763, upload-time = "2026-05-18T18:21:02.386Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -251,12 +322,36 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/75/c7988cb0b90ab9d6728d4c444f09256cfdc97606c1638d8a8090eeb57f7e/cyclopts-4.14.1.tar.gz", hash = "sha256:5d01fc3a940a0e4e872a81ed533a10c1892b5baaa4121fe69528a2b8c17fc9d0", size = 177281, upload-time = "2026-05-19T19:49:22.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/1d/f6c80f82a42c69ff5a86c2580e789133de387d067210c7c46677618a2ca7/cyclopts-4.14.1-py3-none-any.whl", hash = "sha256:b705fdaa3277554a5da03e9bb5ff96a44d204a1afe3099f1b56e1586488bbfd4", size = 214925, upload-time = "2026-05-19T19:49:23.559Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -270,6 +365,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
 
 [[package]]
@@ -397,6 +501,48 @@ wheels = [
 ]
 
 [[package]]
+name = "fastmcp"
+version = "3.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pyperclip" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -456,6 +602,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -474,6 +629,48 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -483,6 +680,86 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/dc/5f768c2e391e9afabe5d18e3221346deb5fb6338565f1ccc9e7c6d7befdd/joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48", size = 231881, upload-time = "2026-05-06T04:58:13.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/3b/ad1cb22e75c963b1f07c8a2329bf47227ce7e4361df5eb2fb101b2ce33ef/joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e", size = 70464, upload-time = "2026-05-06T04:58:11.668Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/79/cd02a4df6d9270efdc7d3feefe6edd730b0820c39eeaa107a2faee8322d5/jsonschema_path-0.5.0.tar.gz", hash = "sha256:493b156ba895c97602655b620a8456caa2ce08c1aa389f5a7addec065e6e855c", size = 19597, upload-time = "2026-05-19T20:45:00.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/2c/9e69d73c4297508be9e3b64a970ea3971b3eb8db64ffc5802d40bd25981f/jsonschema_path-0.5.0-py3-none-any.whl", hash = "sha256:2790a070bc7abb08ea3dbe4d340ece4efadf639223001f020c7503229ba068e2", size = 24077, upload-time = "2026-05-19T20:44:59.225Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -668,12 +945,46 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
 ]
 
 [[package]]
@@ -723,12 +1034,45 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.42.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/ca/25288069c399be6769159d9fb7b1190b603537d82aad2fa2746a0cc2c8c6/opentelemetry_api-1.42.0.tar.gz", hash = "sha256:ea84c893ad177791d138e0349d6ceebd8d3bf006440900400ce220008dafc372", size = 72300, upload-time = "2026-05-19T09:46:29.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/0b/be5daf659b82b525338fde371dfcfab09b606a19bb5620c37076964710ec/opentelemetry_api-1.42.0-py3-none-any.whl", hash = "sha256:558d88f88192a973579910ef6f2c13db47a268d5ec2e53e83e50e74a39a02922", size = 61310, upload-time = "2026-05-19T09:46:06.561Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
 ]
 
 [[package]]
@@ -741,12 +1085,46 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "py-key-value-aio"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
 ]
 
 [[package]]
@@ -882,6 +1260,15 @@ crypto = [
 ]
 
 [[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -941,6 +1328,28 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -977,6 +1386,19 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -987,6 +1409,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/56/3191bae66b08ccc637ea8120426068bcb361cc323c96404c310886937067/rich_rst-2.0.1.tar.gz", hash = "sha256:cbe236ed0901d1ec8427cc6a50bf0a34353ba28ad014dc24def68bfe7f3b9e68", size = 300570, upload-time = "2026-05-16T00:47:57.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/3d/55c17d3ebdf3cd81356002afe5bef9bb8af631db2819785b6eac845b925b/rich_rst-2.0.1-py3-none-any.whl", hash = "sha256:7ee15f345ce25fa02b582c272a6cdbaf0c21243e38061cea273cff659bf3ef61", size = 272922, upload-time = "2026-05-16T00:47:55.508Z" },
 ]
 
 [[package]]
@@ -1057,6 +1492,72 @@ wheels = [
 ]
 
 [[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1082,6 +1583,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "sentry-sdk"
 version = "2.55.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1101,6 +1615,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
 ]
 
 [[package]]
@@ -1158,6 +1685,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New optional MCP sub-app mounted at `/mcp` exposes `GET /reservations` (Resource) and `GET /reservations/{connectionId}` (ResourceTemplate); all state-changing routes are excluded via FastMCP route maps.
- Three new opt-in settings (`AGGREGATOR_PROXY_MCP_ENABLED`, `MCP_PATH`, `MCP_AUTH_ENABLED`) — feature is off by default.
- Auth model: when REST auth is enabled, an httpx event hook forwards the MCP client's `Authorization` header so the existing `get_authenticated_user` dependency re-validates. MCP-level OIDC is enforced by FastMCP's `JWTVerifier`. Startup validation refuses incompatible flag combinations (`AUTH_ENABLED=true` + `MCP_AUTH_ENABLED=false`, or `MCP_AUTH_ENABLED=true` without explicit `OIDC_JWKS_URI`).

Design spec and implementation plan live in `docs/superpowers/specs/` and `docs/superpowers/plans/`.

## Test plan
- [x] Unit tests for route filtering, token-forwarding hook behaviour (4 branches), OIDC wiring, and startup validation
- [x] End-to-end integration test using `fastmcp.Client` against an in-process app with a mocked aggregator (list resource, detail template, unknown-id error)
- [x] Full suite passes: 287 tests (+18 new)
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy aggregator_proxy` all clean
- [ ] Manual smoke: enable MCP locally and read a reservation through `fastmcp.Client`

🤖 Generated with [Claude Code](https://claude.com/claude-code)