### PR TITLE
Bump starlette to 1.3.1 to fix GHSA-82w8-qh3p-5jfq

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1712,14 +1712,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.3.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/37/cc24e33974e1439cf5ca62b0735b63026eabb768f472d8775f52d5851ed9/starlette-1.3.0.tar.gz", hash = "sha256:bb58cbb7a699da4ee4be9ed4cdfe4bc5b0390aa6dac1d1ac714ebebe8dc3c8df", size = 2702493, upload-time = "2026-06-11T06:27:41.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/42/56d31c5ee52dab0ad893d67d4f9c00f5ba2b4c5d87f392eca2c3fdce01cf/starlette-1.3.0-py3-none-any.whl", hash = "sha256:ff4ca1bc23de6a45cdfbbeb9b3caaea524c9221cdd8a6684ad7a4f651a83890b", size = 73492, upload-time = "2026-06-11T06:27:40.444Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes Dependabot alert [#23](https://github.com/workfloworchestrator/nsi-aggregator-proxy/security/dependabot/23).

## What

Bumps the transitive dependency **starlette** `1.3.0 → 1.3.1` in `uv.lock`.

## Why

**GHSA-82w8-qh3p-5jfq** (high): Starlette silently ignores `request.form()` size/field limits for `application/x-www-form-urlencoded` bodies, enabling a DoS via large form payloads. Vulnerable range `>= 0.4.1, < 1.3.1`.

starlette reaches us only transitively (via `fastapi`, `mcp`, `sse-starlette`); their constraints already permit `1.3.1`, so only `uv.lock` changes — no `pyproject.toml` edit needed.

## Verification

- `uv lock --upgrade-package starlette` → `1.3.1`
- `uv run pytest` → 298 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)